### PR TITLE
feat: add sholdKickUsersOnHostLeave

### DIFF
--- a/src/common/types/sdk-options.types.ts
+++ b/src/common/types/sdk-options.types.ts
@@ -3,6 +3,7 @@ import { UserType } from './user.types';
 
 export interface SuperVizSdkOptions {
   debug?: boolean;
+  sholdKickUsersOnHostLeave?: boolean;
   roomId: string;
   organization: OrganizationType;
   user: UserType;

--- a/src/services/communicator/index.ts
+++ b/src/services/communicator/index.ts
@@ -16,6 +16,7 @@ class Communicator {
   private debug: boolean = false;
   private language: string = 'en';
   private roomId: string;
+  private sholdKickUsersOnHostLeave: boolean;
   private user: UserType;
   private realtime: PhotonRealtimeService;
   private organization: OrganizationType;
@@ -29,12 +30,14 @@ class Communicator {
     photonAppId,
     organization,
     user,
+    sholdKickUsersOnHostLeave,
   }: CommunicatorType) {
     this.debug = debug;
     this.language = language;
     this.roomId = roomId;
     this.user = user;
     this.organization = organization;
+    this.sholdKickUsersOnHostLeave = sholdKickUsersOnHostLeave ?? true;
 
     this.realtime = RealtimeService.build();
 
@@ -70,6 +73,7 @@ class Communicator {
       },
       roomId: this.roomId,
       photonAppId,
+      sholdKickUsersOnHostLeave: this.sholdKickUsersOnHostLeave,
     });
   }
 

--- a/src/services/realtime/photon/index.ts
+++ b/src/services/realtime/photon/index.ts
@@ -40,6 +40,7 @@ export default class PhotonRealtimeService {
   currentReconnecAttempt: number;
   oldSyncProperties: {} = {};
   region: PHOTON_REGIONS;
+  sholdKickUsersOnHostLeave: boolean;
   actorObservers: ObserverHelper[];
   actorsObserver: ObserverHelper;
   subscribeToActorsUpdate: Function;
@@ -132,10 +133,11 @@ export default class PhotonRealtimeService {
     this.unsubscribeFromKickAllUsers = this.kickAllUsersObserver.unsubscribe;
   }
 
-  start({ actorInfo, photonAppId, roomId }: StartRealtimeType) {
+  start({ actorInfo, photonAppId, roomId, sholdKickUsersOnHostLeave }: StartRealtimeType) {
     // @TODO - Implement this
     this.region = PHOTON_REGIONS.default;
     this.enableSync = true;
+    this.sholdKickUsersOnHostLeave = sholdKickUsersOnHostLeave;
 
     if (!this.client) {
       this.buildClient(photonAppId);
@@ -658,7 +660,7 @@ export default class PhotonRealtimeService {
       .filter((actor) => actor?.customProperties?.isHostCandidate)
       .map((actor) => actor.actorNr);
 
-    if (!hostCandidatesNr.length) {
+    if (this.sholdKickUsersOnHostLeave && !hostCandidatesNr.length) {
       KICK_USERS_TIMEOUT = setTimeout(() => {
         this.kickAllUsersObserver.publish(true);
       }, KICK_USERS_TIME);

--- a/src/services/realtime/photon/types.ts
+++ b/src/services/realtime/photon/types.ts
@@ -62,4 +62,5 @@ export interface StartRealtimeType {
   actorInfo: ActorInfoType;
   roomId: string;
   photonAppId: string;
+  sholdKickUsersOnHostLeave: boolean;
 }


### PR DESCRIPTION
- feat: add wait for host
- refactor: change isEligibleForHost to isHostCandidate
- fix: unsubscribe to realtime-join event when sdk is destroyed
- feat: add auto pass from host to another candidate
- refactor: remove the leave method and put the leave on destroy
- feat: adds a 1 minute timeout before knocking users out of the room when there is no host
- feat: add sholdKickUsersOnHostLeave option
