### PR TITLE
feat: connection listeners and reconnection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superviz/sdk",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "description": "SuperViz SDK",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superviz/sdk",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "description": "SuperViz SDK",
   "main": "dist/index.js",
   "scripts": {

--- a/src/common/types/events.types.ts
+++ b/src/common/types/events.types.ts
@@ -16,6 +16,7 @@ export enum MeetingEvent {
   MEETING_DEVICES_CHANGE = 'meeting.devices-change',
   MEETING_KICK_USERS = 'meeting.kick-all-users',
   MEETING_STATE_UPDATE = 'meeting.state-update',
+  MEETING_CONNECTION_STATUS_CHANGE = 'meeting.connection-status-change',
 
   MY_USER_UPDATED = 'my-user.update',
   MY_USER_LEFT = 'my-user.left',
@@ -41,9 +42,31 @@ export enum MeetingState {
   MEETING_READY_TO_JOIN = 2,
   MEETING_CONNECTING = 3,
   MEETING_CONNECTED = 4,
-  FRAME_INITIALIZING = 5,
-  FRAME_INITIALIZED = 6,
-  FRAME_UNINITIALIZED = 7,
+  MEETING_RECONNECT = 5,
+
+  FRAME_INITIALIZING = 6,
+  FRAME_INITIALIZED = 7,
+  FRAME_UNINITIALIZED = 8,
+}
+
+/**
+ * @enum { number }
+ * @description Defines the possible Meeting connection states
+ * @options
+ * * NOT_AVAILABLE: Audio/video service is disconnected;
+ * * GOOD: Good connection;
+ * * BAD: Bad connection. Turn off video is recommended;
+ * * POOR: Poor connection. User connection and/or PC not meet the minimum requirements;
+ * * DISCONNECTED: Audio/video is not able to send/receive network packets for at least 10 secs;
+ * * RECONNECTING: Reconnecting due to loss of connection.
+ */
+export enum MeetingConnectionStatus {
+  NOT_AVAILABLE = 0,
+  GOOD = 1,
+  BAD = 2,
+  POOR = 3,
+  DISCONNECTED = 4,
+  RECONNECTING = 5,
 }
 
 export enum DeviceEvent {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {
   RealtimeEvent,
   DeviceEvent,
   MeetingState,
+  MeetingConnectionStatus,
 } from './common/types/events.types';
 import { SuperVizSdkOptions } from './common/types/sdk-options.types';
 import { User, UserGroup } from './common/types/user.types';
@@ -72,4 +73,5 @@ export {
   MeetingState,
   User,
   UserGroup,
+  MeetingConnectionStatus,
 };

--- a/src/services/communicator/index.ts
+++ b/src/services/communicator/index.ts
@@ -3,6 +3,7 @@ import isEqual from 'lodash.isequal';
 
 import {
   DeviceEvent,
+  MeetingConnectionStatus,
   MeetingEvent,
   MeetingState,
   RealtimeEvent,
@@ -63,6 +64,7 @@ class Communicator {
     this.videoManager.subscribeToUserJoined(this.onUserJoined);
     this.videoManager.subscribeToUserLeft(this.onUserLeft);
     this.videoManager.meetingStateObserver.subscribe(this.onMeetingStateUpdate);
+    this.videoManager.meetingConnectionObserver.subscribe(this.publishConnectionStatus);
 
     // Realtime observers
     this.realtime.subscribeToRoomInfoUpdated(this.onActorsListDidChange);
@@ -103,6 +105,8 @@ class Communicator {
     this.videoManager.unsubscribeFromUserListUpdate(this.onUserListUpdate);
     this.videoManager.unsubscribeFromUserJoined(this.onUserJoined);
     this.videoManager.unsubscribeFromUserLeft(this.onUserLeft);
+    this.videoManager.meetingStateObserver.unsubscribe(this.onMeetingStateUpdate);
+    this.videoManager.meetingConnectionObserver.unsubscribe(this.publishConnectionStatus);
 
     this.realtime.unsubscribeFromRoomInfoUpdated(this.onActorsListDidChange);
     this.realtime.unsubscribeFromMasterActorUpdate(this.onMasterActorDidChange);
@@ -234,6 +238,10 @@ class Communicator {
 
   private onMeetingStateUpdate = (newState: MeetingState) => {
     this.publish(MeetingEvent.MEETING_STATE_UPDATE, newState);
+  };
+
+  private publishConnectionStatus = (newStatus: MeetingConnectionStatus): void => {
+    this.publish(MeetingEvent.MEETING_CONNECTION_STATUS_CHANGE, newStatus);
   };
 }
 

--- a/src/services/video-conference-manager/index.ts
+++ b/src/services/video-conference-manager/index.ts
@@ -3,6 +3,7 @@ import { FrameBricklayer, MessageBridge, ObserverHelper } from '@superviz/immers
 import videoConferenceStyle from '../../common/styles/videoConferenceStyle';
 import {
   DeviceEvent,
+  MeetingConnectionStatus,
   MeetingEvent,
   MeetingState,
   RealtimeEvent,
@@ -25,6 +26,7 @@ export default class VideoConfereceManager {
   private sameAccountErrorObserver = new ObserverHelper({ logger });
   private devicesObserver = new ObserverHelper({ logger });
   public meetingStateObserver = new ObserverHelper({ logger });
+  public meetingConnectionObserver = new ObserverHelper({ logger });
 
   private userAmountUpdateObserver = new ObserverHelper({ logger });
   private userJoinedObserver = new ObserverHelper({ logger });
@@ -105,6 +107,10 @@ export default class VideoConfereceManager {
     this.messageBridge.listen(MeetingEvent.MEETING_GRID_MODE_CHANGE, this.onGridModeChange);
     this.messageBridge.listen(MeetingEvent.MEETING_SAME_USER_ERROR, this.onSameAccountError);
     this.messageBridge.listen(MeetingEvent.MEETING_STATE_UPDATE, this.meetingStateUpdate);
+    this.messageBridge.listen(
+      MeetingEvent.MEETING_CONNECTION_STATUS_CHANGE,
+      this.onConnectionStatusChange,
+    );
     this.messageBridge.listen(MeetingEvent.MEETING_DEVICES_CHANGE, this.onDevicesChange);
     this.messageBridge.listen(RealtimeEvent.REALTIME_JOIN, this.realtimeJoin);
 
@@ -197,6 +203,10 @@ export default class VideoConfereceManager {
 
   private meetingStateUpdate = (newState: MeetingState): void => {
     this.meetingStateObserver.publish(newState);
+  };
+
+  private onConnectionStatusChange = (newStatus: MeetingConnectionStatus): void => {
+    this.meetingConnectionObserver.publish(newStatus);
   };
 
   public subscribeToFrameState = this.frameStateObserver.subscribe;


### PR DESCRIPTION
Implements SuperViz SDK connection statuses for the audio/video service.

Connection status can be obtained in real time by subscribing to `MEETING_CONNECTION_STATUS_CHANGE`. And all possible statuses are in the `MeetingConnectionStatus` enum

---

The description of each status:

  * NOT_AVAILABLE: Audio/video service is disconnected;
  * GOOD: Good connection;
  * BAD: Bad connection. Turn off video is recommended;
  * POOR: Poor connection. User connection and/or PC does not meet the minimum requirements;
  * DISCONNECTED: Audio/video is not able to send/receive network packets for at least 10 secs;
  * RECONNECTING: Reconnecting due to loss of connection.
  * LOST_CONNECTION: The connection to the audio/video service was lost. You must end the meeting and start again.