### PR TITLE
fix: don't replace avatarUrl if its undefined

### DIFF
--- a/src/services/realtime/ably/index.ts
+++ b/src/services/realtime/ably/index.ts
@@ -364,13 +364,14 @@ export default class AblyRealtimeService extends RealtimeService implements Ably
       return;
     }
 
+    if (newProperties.avatarUrl === undefined) {
+      delete newProperties.avatarUrl;
+    }
     this.myActor.data = {
       ...this.myActor.data,
       ...newProperties,
     };
-    if (newProperties.avatarUrl) {
-      this.myActor.data.avatarUrl = newProperties.avatarUrl;
-    }
+
 
     if (!this.isJoinedRoom || !this.enableSync) {
       return;


### PR DESCRIPTION
fix: don't replace avatarUrl if its undefined