### PR TITLE
fix: added local configuration file 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dist/
 coverage/
 .DS_Store
 .version.js
+.remote-config.js

--- a/src/common/types/sdk-options.types.ts
+++ b/src/common/types/sdk-options.types.ts
@@ -5,6 +5,7 @@ import type { Participant, Group, Avatar } from './participant.types';
 export type FramePosition = 'right' | 'left' | 'bottom' | 'top';
 
 export enum EnvironmentTypes {
+  LOCAL = 'local',
   DEV = 'dev',
   PROD = 'prod',
 }

--- a/src/services/remote-config-service/index.ts
+++ b/src/services/remote-config-service/index.ts
@@ -9,6 +9,10 @@ export default class RemoteConfigService {
   static async getRemoteConfig(
     environment: EnvironmentTypes = EnvironmentTypes.PROD,
   ): Promise<any> {
+    if (environment === EnvironmentTypes.LOCAL) {
+      const { remoteConfig } = await import('../../../.remote-config');
+      return remoteConfig;
+    }
     const remoteConfigParams: RemoteConfigParams = {
       version,
       environment,


### PR DESCRIPTION
With this feature, the user can get the remoteConfig (apikey and conferenceLayerUrl) locally.

for use this, the user need to create a .remote-config.js file in root directory with this content:

```
export const remoteConfig = {
    apiUrl: 'https://localhost:4000', //your api url
    conferenceLayerUrl: 'https://localhost:8080', //your video-frame url
}
```

and set the `environment: 'local'` in SDK initialization.