### PR TITLE
fix: realtime channel names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import Communicator from './services/communicator';
 import { SuperVizSdk, PluginOptions } from './services/communicator/types';
 import { PluginMethods, Plugin } from './services/integration/base-plugin/types';
 import { ParticipantOn3D, ParticipantTo3D } from './services/integration/participants/types';
+import { RealtimeMessage } from './services/realtime/ably/types';
 import RemoteConfigService from './services/remote-config-service';
 import { ColorsVariables, ColorsVariablesNames } from './services/video-conference-manager/types';
 
@@ -133,4 +134,5 @@ export {
   Avatar,
   MeetingControlsEvent,
   DevicesOptions,
+  RealtimeMessage,
 };

--- a/src/services/realtime/ably/index.ts
+++ b/src/services/realtime/ably/index.ts
@@ -359,7 +359,7 @@ export default class AblyRealtimeService extends RealtimeService implements Ably
    * @description publish client sync props
    * @returns {void}
    */
-  private publishClientSyncProperties = async (): Promise<void> => {
+  private publishClientSyncProperties = (): void => {
     if (this.state !== RealtimeStateTypes.CONNECTED) return;
 
     Object.keys(this.clientSyncPropertiesQueue).forEach((name) => {


### PR DESCRIPTION
The channel names were confusing and difficult to distinguish between them, so I think it could be simpler