### PR TITLE
feat: added support to transcription service

### DIFF
--- a/src/common/types/events.types.ts
+++ b/src/common/types/events.types.ts
@@ -53,6 +53,11 @@ export enum RealtimeEvent {
   REALTIME_SET_AVATAR = 'realtime.set-avatar',
 }
 
+export enum TranscriptionEvent {
+  TRANSCRIPTION_START = 'transcription.start',
+  TRANSCRIPTION_STOP = 'transcription.stop',
+}
+
 export enum MeetingState {
   MEETING_FAILED = -1,
   MEETING_DISCONNECTED = 0,

--- a/src/services/communicator/index.ts
+++ b/src/services/communicator/index.ts
@@ -337,6 +337,14 @@ class Communicator {
     );
   };
 
+  public startTranscription = (language): void => {
+    this.videoManager.startTranscription(language);
+  };
+
+  public stopTranscription = (): void => {
+    this.videoManager.stopTranscription();
+  };
+
   private publish = (type: string, data: any): void => {
     const hasListenerRegistered = type in this.observerHelpers;
 
@@ -619,6 +627,9 @@ export default (params: CommunicatorOptions): SuperVizSdk => {
     toggleScreenShare: () => communicator.toggleScreenShare(),
     hangUp: () => communicator.hangUp(),
     toggleChat: () => communicator.toggleChat(),
+
+    startTranscription: (language) => communicator.startTranscription(language),
+    stopTranscription: () => communicator.stopTranscription(),
 
     loadPlugin: (plugin, props) => communicator.loadPlugin(plugin, props),
     unloadPlugin: () => communicator.unloadPlugin(),

--- a/src/services/communicator/types.ts
+++ b/src/services/communicator/types.ts
@@ -31,6 +31,9 @@ export type SuperVizSdk = {
   toggleCam: () => void;
   toggleChat: () => void;
 
+  startTranscription: (language: string) => void;
+  stopTranscription: () => void;
+
   loadPlugin: (plugin: Plugin, props: PluginOptions) => PluginMethods;
   unloadPlugin: () => void;
 };

--- a/src/services/video-conference-manager/index.ts
+++ b/src/services/video-conference-manager/index.ts
@@ -11,6 +11,7 @@ import {
   Dimensions,
   MeetingControlsEvent,
   FrameEvent,
+  TranscriptionEvent,
 } from '../../common/types/events.types';
 import { StartMeetingOptions } from '../../common/types/meeting.types';
 import { Participant, Avatar } from '../../common/types/participant.types';
@@ -640,5 +641,21 @@ export default class VideoConfereceManager {
    */
   public toggleCam(): void {
     this.messageBridge.publish(MeetingControlsEvent.TOGGLE_CAM);
+  }
+
+  /**
+   * @function startTranscription
+   * @returns {void}
+   */
+  public startTranscription(language): void {
+    this.messageBridge.publish(TranscriptionEvent.TRANSCRIPTION_START, language);
+  }
+
+  /**
+   * @function stopTranscription
+   * @returns {void}
+   */
+  public stopTranscription(): void {
+    this.messageBridge.publish(TranscriptionEvent.TRANSCRIPTION_STOP);
   }
 }


### PR DESCRIPTION
## What

Users can create transcripts of their meetings, which is very useful for later analysis and especially searching for keywords or specific contexts. You need to choose language on start the transcription, the default language is `en-US`.

## Implementation

```
// Default language is en-US
sdk.startTranscription(language: string) => Promise<void>

sdk.stopTranscription() => Promise<void>
```

Users can use Start and Stop functions to control the transcription, we recommend only host can control the transcription service.

Example:

```
// start the meeting with pt-BR language
sdk.startTranscription('pt-BR')
```


```
// stop the meeting
sdk.stopTranscription()
```