### PR TITLE
fix: calc parent dimensions considering offset

### DIFF
--- a/src/services/video-conference-manager/index.ts
+++ b/src/services/video-conference-manager/index.ts
@@ -369,7 +369,14 @@ export default class VideoConfereceManager {
    * @returns {void}
    */
   private onWindowResize = (): void => {
-    const { innerHeight: height, innerWidth: width } = window;
+    const { top, bottom, right, left } = this.frameOffset;
+    const { innerHeight, innerWidth } = window;
+
+    const height = innerHeight - top - bottom;
+    const width = innerWidth - right - left;
+
+    // when the frame is not mounted, the message bridge is not available
+    if (!this.messageBridge) return;
 
     this.messageBridge.publish(FrameEvent.FRAME_PARENT_SIZE_UPDATE, { height, width });
   };


### PR DESCRIPTION

## Problem

`FrameEvent.FRAME_PARENT_SIZE_UPDATE` was not considering the offset when sending the size of the parent

---
![offset](https://github.com/SuperViz/sdk/assets/49524331/6a550daf-62e5-4f6b-b7b3-2c75c26bdfa5)
