### PR TITLE
fix: change the transcript events to send message to video-frame

### DIFF
--- a/src/common/types/events.types.ts
+++ b/src/common/types/events.types.ts
@@ -52,11 +52,13 @@ export enum RealtimeEvent {
   REALTIME_FOLLOW_PARTICIPANT = 'realtime.follow-participant',
   REALTIME_SET_AVATAR = 'realtime.set-avatar',
   REALTIME_DRAWING_CHANGE = 'realtime.drawing-change',
+  REALTIME_TRANSCRIPT_CHANGE = 'realtime.transcript-change',
 }
 
-export enum TranscriptionEvent {
-  TRANSCRIPTION_START = 'transcription.start',
-  TRANSCRIPTION_STOP = 'transcription.stop',
+export enum TranscriptState {
+  TRANSCRIPT_START = 'transcript.start',
+  TRANSCRIPT_RUNNING = 'transcript.running',
+  TRANSCRIPT_STOP = 'transcript.stop',
 }
 
 export enum MeetingState {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -38,8 +38,6 @@ const COMMUNICATOR_INSTANCE_MOCK = {
   toggleScreenShare: jest.fn(),
   hangUp: jest.fn(),
   toggleChat: jest.fn(),
-  startTranscription: jest.fn(),
-  stopTranscription: jest.fn(),
   loadPlugin: jest.fn(),
   unloadPlugin: jest.fn(),
 };
@@ -83,11 +81,7 @@ jest.mock('./services/api');
 jest.mock('./services/auth-service', () => ({
   __esModule: true,
   default: jest.fn().mockImplementation((_, apiKey: string) => {
-    if (apiKey === UNIT_TEST_API_KEY) {
-      return true;
-    }
-
-    return false;
+    return apiKey === UNIT_TEST_API_KEY;
   }),
 }));
 jest.mock('./services/remote-config-service');

--- a/src/services/communicator/ index.test.ts
+++ b/src/services/communicator/ index.test.ts
@@ -1,7 +1,4 @@
-import exp from 'constants';
-
 import { MOCK_OBSERVER_HELPER } from '../../../__mocks__/observer-helper.mock';
-import { MOCK_LOCAL_PARTICIPANT } from '../../../__mocks__/participants.mock';
 import {
   MOCK_AVATAR_CONFIG,
   MOCK_PARTICIPANT_TO_3D,
@@ -10,7 +7,6 @@ import {
 import {
   MeetingControlsEvent,
   RealtimeEvent,
-  TranscriptionEvent,
 } from '../../common/types/events.types';
 import { AblyRealtimeService } from '../realtime';
 
@@ -131,8 +127,6 @@ describe('Communicator', () => {
     expect(communicator).toHaveProperty('hangUp');
     expect(communicator).toHaveProperty('toggleCam');
     expect(communicator).toHaveProperty('toggleChat');
-    expect(communicator).toHaveProperty('startTranscription');
-    expect(communicator).toHaveProperty('stopTranscription');
     expect(communicator).toHaveProperty('loadPlugin');
     expect(communicator).toHaveProperty('unloadPlugin');
   });
@@ -397,46 +391,6 @@ describe('Communicator', () => {
       expect(communicator.toggleChat).toBeCalled();
       expect(VideoManagerMock.publishMessageToFrame).toBeCalledWith(
         MeetingControlsEvent.TOGGLE_MEETING_CHAT,
-      );
-    });
-  });
-
-  describe('startTranscription', () => {
-    let communicator: SuperVizSdk;
-
-    beforeEach(() => {
-      jest.clearAllMocks();
-      communicator = Communicator(COMMUNICATOR_INITIALIZATION_MOCK);
-    });
-
-    test('should call the startTranscription method', () => {
-      jest.spyOn(communicator, 'startTranscription');
-      communicator.startTranscription('en-US');
-
-      expect(communicator.startTranscription).toBeCalled();
-      expect(VideoManagerMock.publishMessageToFrame).toBeCalledWith(
-        TranscriptionEvent.TRANSCRIPTION_START,
-        'en-US',
-      );
-    });
-  });
-
-  describe('stopTranscription', () => {
-    let communicator: SuperVizSdk;
-
-    beforeEach(() => {
-      jest.clearAllMocks();
-      communicator = Communicator(COMMUNICATOR_INITIALIZATION_MOCK);
-    });
-
-    test('should call the stopTranscription method', () => {
-      jest.spyOn(communicator, 'stopTranscription');
-      communicator.stopTranscription();
-
-      expect(communicator.stopTranscription).toBeCalled();
-      expect(VideoManagerMock.publishMessageToFrame).toBeCalledWith(
-        TranscriptionEvent.TRANSCRIPTION_STOP,
-        undefined,
       );
     });
   });

--- a/src/services/communicator/ index.test.ts
+++ b/src/services/communicator/ index.test.ts
@@ -50,6 +50,7 @@ const AblyRealtimeMock = {
   start: jest.fn(),
   leave: jest.fn(),
   setFollowParticipant: jest.fn(),
+  setTranscript: jest.fn(),
   fetchSyncClientProperty: jest.fn((key?: string) => {
     if (key) {
       return createRealtimeMessage(key);
@@ -88,6 +89,7 @@ const VideoManagerMock = {
   meetingConnectionObserver: MOCK_OBSERVER_HELPER,
   participantJoinedObserver: MOCK_OBSERVER_HELPER,
   participantLeftObserver: MOCK_OBSERVER_HELPER,
+  transcriptChangeObserver: MOCK_OBSERVER_HELPER,
 };
 
 jest.mock('../realtime', () => ({
@@ -103,7 +105,7 @@ describe('Communicator', () => {
     expect(Communicator).toBeDefined();
   });
 
-  test('should exprt a function', () => {
+  test('should expect a function', () => {
     expect(typeof Communicator).toBe('function');
   });
 
@@ -232,6 +234,7 @@ describe('Communicator', () => {
       expect(VideoManagerMock.participantLeftObserver.unsubscribe).toBeCalled();
       expect(VideoManagerMock.meetingStateObserver.unsubscribe).toBeCalled();
       expect(VideoManagerMock.meetingConnectionObserver.unsubscribe).toBeCalled();
+      expect(VideoManagerMock.transcriptChangeObserver.unsubscribe).toBeCalled();
     });
   });
 

--- a/src/services/communicator/types.ts
+++ b/src/services/communicator/types.ts
@@ -2,7 +2,7 @@ import { SuperVizSdkOptions } from '../../common/types/sdk-options.types';
 import { Plugin, PluginMethods, DefaultPluginOptions } from '../integration/base-plugin/types';
 import { AvatarConfig } from '../integration/participants/types';
 import { RealtimeMessage } from '../realtime/ably/types';
-import { LayoutPosition, WaterMark } from '../video-conference-manager/types';
+import { WaterMark } from '../video-conference-manager/types';
 
 export interface CommunicatorOptions extends SuperVizSdkOptions {
   apiKey: string;
@@ -42,9 +42,6 @@ export type SuperVizSdk = {
   hangUp: () => void;
   toggleCam: () => void;
   toggleChat: () => void;
-
-  startTranscription: (language: string) => void;
-  stopTranscription: () => void;
 
   loadPlugin: (plugin: Plugin, props: PluginOptions) => PluginMethods;
   unloadPlugin: () => void;

--- a/src/services/realtime/ably/index.test.ts
+++ b/src/services/realtime/ably/index.test.ts
@@ -349,7 +349,7 @@ describe('AblyRealtimeService', () => {
       AblyRealtimeServiceInstance.setTranscript(transcriptionState);
 
       expect(AblyRealtimeServiceInstance['updateRoomProperties']).toHaveBeenCalledWith({
-        transcriptionState,
+        transcript: transcriptionState,
       });
     });
 

--- a/src/services/realtime/ably/index.test.ts
+++ b/src/services/realtime/ably/index.test.ts
@@ -3,6 +3,7 @@ import { TextEncoder } from 'util';
 import Ably from 'ably';
 
 import { MOCK_AVATAR, MOCK_LOCAL_PARTICIPANT } from '../../../../__mocks__/participants.mock';
+import { TranscriptState } from '../../../common/types/events.types';
 import { ParticipantType } from '../../../common/types/participant.types';
 import { RealtimeStateTypes } from '../../../common/types/realtime.types';
 import { ParticipantInfo } from '../base/types';
@@ -191,7 +192,7 @@ describe('AblyRealtimeService', () => {
     expect(AblyRealtimeMock.connection.on).toHaveBeenCalledTimes(1);
   });
 
-  test('should subscribe to broadcast channe if participant is audience', () => {
+  test('should subscribe to broadcast channel if participant is audience', () => {
     expect(AblyRealtimeServiceInstance.join).toBeDefined();
 
     const participant: ParticipantInfo = {
@@ -339,6 +340,19 @@ describe('AblyRealtimeService', () => {
         drawing,
       });
     });
+
+    test('should update the room properties with transcript state', () => {
+      AblyRealtimeServiceInstance['updateRoomProperties'] = jest.fn();
+
+      const transcriptionState = TranscriptState.TRANSCRIPT_START;
+
+      AblyRealtimeServiceInstance.setTranscript(transcriptionState);
+
+      expect(AblyRealtimeServiceInstance['updateRoomProperties']).toHaveBeenCalledWith({
+        transcriptionState,
+      });
+    });
+
     /**
      * initializeRoomProperties
      */

--- a/src/services/realtime/ably/index.ts
+++ b/src/services/realtime/ably/index.ts
@@ -1,7 +1,7 @@
 import Ably from 'ably';
 import throttle from 'lodash/throttle';
 
-import { RealtimeEvent } from '../../../common/types/events.types';
+import { RealtimeEvent, TranscriptState } from '../../../common/types/events.types';
 import { ParticipantType } from '../../../common/types/participant.types';
 import { RealtimeStateTypes } from '../../../common/types/realtime.types';
 import { logger } from '../../../common/utils';
@@ -163,7 +163,7 @@ export default class AblyRealtimeService extends RealtimeService implements Ably
   }
 
   /**
-   * @function Join
+   * @function join
    * @description join realtime room
    * @returns {void}
    * @param joinProperties
@@ -269,6 +269,17 @@ export default class AblyRealtimeService extends RealtimeService implements Ably
   public setDrawing(drawing: DrawingData): void {
     const roomProperties = this.localRoomProperties;
     this.updateRoomProperties(Object.assign({}, roomProperties, { drawing }));
+  }
+
+  /**
+   * @function setTranscript
+   * @param state {TranscriptState}
+   * @description synchronizes the transcript state in the room
+   * @returns {void}
+   */
+  public setTranscript(state: TranscriptState): void {
+    const roomProperties = this.localRoomProperties;
+    this.updateRoomProperties(Object.assign({}, roomProperties, { transcript: state }));
   }
 
   /**
@@ -805,13 +816,13 @@ export default class AblyRealtimeService extends RealtimeService implements Ably
    * @function fetchSyncClientProperty
    * @description
    * @param {string} eventName - name event to be fetched
-   * @returns {ClientRealtimeData}
+   * @returns {Promise<RealtimeMessage | Record<string, RealtimeMessage>}
    */
   public async fetchSyncClientProperty(
     eventName?: string,
   ): Promise<RealtimeMessage | Record<string, RealtimeMessage>> {
     try {
-      const clienthistory: Record<string, RealtimeMessage> = await new Promise(
+      const clientHistory: Record<string, RealtimeMessage> = await new Promise(
         (resolve, reject) => {
           this.clientRoomStateChannel.history((error, resultPage) => {
             if (error) reject(error);
@@ -827,15 +838,15 @@ export default class AblyRealtimeService extends RealtimeService implements Ably
         },
       );
 
-      if (eventName && !clienthistory[eventName]) {
+      if (eventName && !clientHistory[eventName]) {
         throw new Error(`Event ${eventName} not found in the history`);
       }
 
       if (eventName) {
-        return clienthistory[eventName];
+        return clientHistory[eventName];
       }
 
-      return clienthistory;
+      return clientHistory;
     } catch (error) {
       logger.log('REALTIME', 'Error in fetch client realtime data', error.message);
       this.throw(error.message);
@@ -1128,6 +1139,7 @@ export default class AblyRealtimeService extends RealtimeService implements Ably
    * @function isMessageTooBig
    * @description calculates the size of a sync message and checks if it's bigger than limit
    * @param {unknown} msg
+   * @param {number} limit
    * @returns {boolean}
    */
   private isMessageTooBig = (msg: unknown, limit: number = MESSAGE_SIZE_LIMIT): boolean => {

--- a/src/services/realtime/ably/types.ts
+++ b/src/services/realtime/ably/types.ts
@@ -1,5 +1,6 @@
 import type Ably from 'ably';
 
+import { TranscriptState } from '../../../common/types/events.types';
 import { DrawingData } from '../../video-conference-manager/types';
 import { DefaultRealtimeMethods } from '../base/types';
 
@@ -18,6 +19,7 @@ export interface AblyRealtimeData {
   gather?: boolean;
   drawing?: DrawingData;
   kickParticipant?: AblyParticipant;
+  transcript?: TranscriptState;
 }
 
 export type AblyTokenCallBack = (

--- a/src/services/video-conference-manager/index.test.ts
+++ b/src/services/video-conference-manager/index.test.ts
@@ -6,7 +6,6 @@ import {
   MeetingControlsEvent,
   MeetingEvent,
   MeetingState,
-  TranscriptionEvent,
 } from '../../common/types/events.types';
 import { Participant } from '../../common/types/participant.types';
 import { BrowserService } from '../browser';

--- a/src/services/video-conference-manager/index.ts
+++ b/src/services/video-conference-manager/index.ts
@@ -7,8 +7,7 @@ import {
   RealtimeEvent,
   Dimensions,
   MeetingControlsEvent,
-  FrameEvent,
-  TranscriptionEvent,
+  FrameEvent, TranscriptState,
 } from '../../common/types/events.types';
 import { StartMeetingOptions } from '../../common/types/meeting.types';
 import { Participant, Avatar } from '../../common/types/participant.types';
@@ -33,7 +32,7 @@ import {
 
 const FRAME_ID = 'sv-video-frame';
 
-export default class VideoConfereceManager {
+export default class VideoConferenceManager {
   private messageBridge: MessageBridge;
   private bricklayer: FrameBricklayer;
   private browserService: BrowserService;
@@ -54,6 +53,7 @@ export default class VideoConfereceManager {
   public readonly kickParticipantObserver = new Observer({ logger });
   public readonly gridModeChangeObserver = new Observer({ logger });
   public readonly drawingChangeObserver = new Observer({ logger });
+  public readonly transcriptChangeObserver = new Observer({ logger });
 
   public readonly followParticipantObserver = new Observer({ logger });
   public readonly goToParticipantObserver = new Observer({ logger });
@@ -264,6 +264,7 @@ export default class VideoConfereceManager {
     this.messageBridge.listen(RealtimeEvent.REALTIME_JOIN, this.realtimeJoin);
     this.messageBridge.listen(RealtimeEvent.REALTIME_GRID_MODE_CHANGE, this.onGridModeChange);
     this.messageBridge.listen(RealtimeEvent.REALTIME_DRAWING_CHANGE, this.onDrawingChange);
+    this.messageBridge.listen(RealtimeEvent.REALTIME_TRANSCRIPT_CHANGE, this.onTranscriptChange);
 
     this.messageBridge.listen(FrameEvent.FRAME_DIMENSIONS_UPDATE, this.onFrameDimensionsUpdate);
     this.messageBridge.listen(
@@ -408,7 +409,7 @@ export default class VideoConfereceManager {
   };
 
   /**
-   * @function updateMeetingAvatar
+   * @function updateMeetingAvatars
    * @description update list of avatars
    * @returns {void}
    */
@@ -519,6 +520,15 @@ export default class VideoConfereceManager {
   };
 
   /**
+   * @function onTranscriptChange
+   * @param state {TranscriptState}
+   * @returns {void}
+   */
+  private onTranscriptChange = (state: TranscriptState): void => {
+    this.transcriptChangeObserver.publish(state);
+  };
+
+  /**
    * @function onSameAccountError
    * @param {string} error
    * @returns {void}
@@ -594,6 +604,7 @@ export default class VideoConfereceManager {
     this.kickParticipantObserver.destroy();
     this.gridModeChangeObserver.destroy();
     this.drawingChangeObserver.destroy();
+    this.transcriptChangeObserver.destroy();
 
     this.followParticipantObserver.destroy();
     this.goToParticipantObserver.destroy();
@@ -612,11 +623,11 @@ export default class VideoConfereceManager {
   /**
    * @function publishMessageToFrame
    * @description Publishes a message to the frame
-   * @param message - The event to publish
+   * @param event - The event to publish
    * @param payload  - The payload to publish
    */
   public publishMessageToFrame(
-    event: MeetingControlsEvent | MeetingEvent | RealtimeEvent | TranscriptionEvent,
+    event: MeetingControlsEvent | MeetingEvent | RealtimeEvent,
     payload?: unknown,
   ): void {
     this.messageBridge.publish(event, payload);


### PR DESCRIPTION
This update internal events from sdk to video-frame in transcript feature, this allows to share the transcript state from participants and change the layout like toolbar and alerts for notify the participants about transcription running.