### PR TITLE
feat: update participant list from meeting service

### DIFF
--- a/src/components/video/index.ts
+++ b/src/components/video/index.ts
@@ -31,7 +31,8 @@ import { ParticipandToFrame, VideoComponentOptions } from './types';
 export class VideoComponent extends BaseComponent {
   public name: string;
   protected logger: Logger;
-  private participantList: ParticipandToFrame[] = [];
+  private participantToFrameList: ParticipandToFrame[] = [];
+  private participantsOnMeeting: Partial<Participant>[] = [];
 
   private videoManager: VideoConfereceManager;
   private connectionService: ConnectionService;
@@ -132,6 +133,7 @@ export class VideoComponent extends BaseComponent {
     this.videoManager.meetingConnectionObserver.subscribe(
       this.connectionService.updateMeetingConnectionStatus,
     );
+    this.videoManager.participantListObserver.subscribe(this.onParticipantListUpdate);
     this.videoManager.waitingForHostObserver.subscribe(this.onWaitingForHost);
     this.videoManager.frameSizeObserver.subscribe(this.onFrameSizeDidChange);
     this.videoManager.meetingStateObserver.subscribe(this.onMeetingStateChange);
@@ -154,6 +156,7 @@ export class VideoComponent extends BaseComponent {
     this.videoManager.meetingConnectionObserver.unsubscribe(
       this.connectionService.updateMeetingConnectionStatus,
     );
+    this.videoManager.participantListObserver.unsubscribe(this.onParticipantListUpdate);
     this.videoManager.waitingForHostObserver.unsubscribe(this.onWaitingForHost);
     this.videoManager.frameSizeObserver.unsubscribe(this.onFrameSizeDidChange);
     this.videoManager.meetingStateObserver.unsubscribe(this.onMeetingStateChange);
@@ -177,7 +180,7 @@ export class VideoComponent extends BaseComponent {
     this.realtime.participantJoinedObserver.subscribe(this.onParticipantJoinedOnRealtime);
     this.realtime.participantLeaveObserver.subscribe(this.onParticipantLeftOnRealtime);
     this.realtime.roomInfoUpdatedObserver.subscribe(this.onRoomInfoUpdated);
-    this.realtime.participantsObserver.subscribe(this.onParticipantsDidChange);
+    this.realtime.participantsObserver.subscribe(this.onRealtimeParticipantsDidChange);
     this.realtime.hostObserver.subscribe(this.onHostParticipantDidChange);
   };
 
@@ -192,7 +195,7 @@ export class VideoComponent extends BaseComponent {
     this.realtime.participantJoinedObserver.unsubscribe(this.onParticipantJoinedOnRealtime);
     this.realtime.participantLeaveObserver.unsubscribe(this.onParticipantLeftOnRealtime);
     this.realtime.roomInfoUpdatedObserver.unsubscribe(this.onRoomInfoUpdated);
-    this.realtime.participantsObserver.unsubscribe(this.onParticipantsDidChange);
+    this.realtime.participantsObserver.unsubscribe(this.onRealtimeParticipantsDidChange);
     this.realtime.hostObserver.unsubscribe(this.onHostParticipantDidChange);
   };
 
@@ -376,11 +379,31 @@ export class VideoComponent extends BaseComponent {
     });
   };
 
+  /**
+   * @function onParticipantLeft
+   * @description handler for participant left event
+   * @param {Participant} _ - participant
+   * @returns {void}
+   */
   private onParticipantLeft = (_: Participant): void => {
     this.logger.log('video component @ on participant left', this.localParticipant);
 
     this.publish(MeetingEvent.MY_PARTICIPANT_LEFT, this.localParticipant);
     this.detach();
+  };
+
+  private onParticipantListUpdate = (participants: Partial<Participant>[]): void => {
+    this.logger.log('video component @ on participant list update', participants);
+
+    if (isEqual(this.participantsOnMeeting, participants)) return;
+
+    this.publish(MeetingEvent.MEETING_PARTICIPANT_LIST_UPDATE, participants);
+
+    if (this.participantsOnMeeting.length !== participants.length) {
+      this.publish(MeetingEvent.MEETING_PARTICIPANT_AMOUNT_UPDATE, participants.length);
+    }
+
+    this.participantsOnMeeting = participants;
   };
 
   /** Realtime Events */
@@ -438,12 +461,14 @@ export class VideoComponent extends BaseComponent {
   };
 
   /**
-   * @function onParticipantsDidChange
+   * @function onRealtimeParticipantsDidChange
    * @description handler for participant list update event
    * @param {Record<string, AblyParticipant>} participants - participants
    * @returns {void}
    */
-  private onParticipantsDidChange = (participants: Record<string, AblyParticipant>): void => {
+  private onRealtimeParticipantsDidChange = (
+    participants: Record<string, AblyParticipant>,
+  ): void => {
     this.logger.log('video component @ on participants did change', participants);
 
     const participantList: ParticipandToFrame[] = Object.values(participants).map(
@@ -454,28 +479,21 @@ export class VideoComponent extends BaseComponent {
           participantId: participant.clientId,
           color: this.realtime.getSlotColor(participant.data.slotIndex).name,
           name: participant.data.name,
+          isHost: this.realtime.hostClientId === participant.clientId,
+          avatar: participant.data.avatar,
+          type: participant.data.type,
         };
       },
     );
 
-    if (!isEqual(this.participantList, participantList)) {
+    if (!isEqual(this.participantToFrameList, participantList)) {
       this.videoManager.publishMessageToFrame(
         RealtimeEvent.REALTIME_PARTICIPANT_LIST_UPDATE,
         participantList,
       );
-
-      const participantsToPublish = Object.values(participants).map((participant) => {
-        return this.createParticipantFromAblyPresence(participant);
-      });
-
-      this.publish(MeetingEvent.MEETING_PARTICIPANT_LIST_UPDATE, participantsToPublish);
     }
 
-    if (this.participantList.length !== participantList.length) {
-      this.publish(MeetingEvent.MEETING_PARTICIPANT_AMOUNT_UPDATE, participantList.length);
-    }
-
-    this.participantList = participantList;
+    this.participantToFrameList = participantList;
   };
 
   /**

--- a/src/components/video/types.ts
+++ b/src/components/video/types.ts
@@ -1,4 +1,4 @@
-import { Avatar } from '../../common/types/participant.types';
+import { Avatar, ParticipantType } from '../../common/types/participant.types';
 import { DevicesOptions } from '../../common/types/sdk-options.types';
 import {
   CamerasPosition,
@@ -37,4 +37,7 @@ export type ParticipandToFrame = {
   participantId: string;
   color: string;
   name: string;
+  isHost: boolean;
+  avatar?: Avatar;
+  type: ParticipantType;
 };

--- a/src/services/video-conference-manager/index.ts
+++ b/src/services/video-conference-manager/index.ts
@@ -61,6 +61,7 @@ export default class VideoConfereceManager {
 
   public readonly participantJoinedObserver = new Observer({ logger: this.logger });
   public readonly participantLeftObserver = new Observer({ logger: this.logger });
+  public readonly participantListObserver = new Observer({ logger: this.logger });
 
   frameState = VideoFrameState.UNINITIALIZED;
 
@@ -252,6 +253,10 @@ export default class VideoConfereceManager {
       this.onWaitingForHostDidChange,
     );
     this.messageBridge.listen(MeetingEvent.MEETING_PARTICIPANT_JOINED, this.onParticipantJoined);
+    this.messageBridge.listen(
+      MeetingEvent.MEETING_PARTICIPANT_LIST_UPDATE,
+      this.onParticipantListUpdate,
+    );
     this.messageBridge.listen(MeetingEvent.MEETING_PARTICIPANT_LEFT, this.onParticipantLeft);
     this.messageBridge.listen(MeetingEvent.MEETING_HOST_CHANGE, this.onMeetingHostChange);
     this.messageBridge.listen(MeetingEvent.MEETING_KICK_PARTICIPANT, this.onMeetingKickParticipant);
@@ -585,6 +590,10 @@ export default class VideoConfereceManager {
 
   private onWaitingForHostDidChange = (isWaitingForHost: boolean): void => {
     this.waitingForHostObserver.publish(isWaitingForHost);
+  };
+
+  private onParticipantListUpdate = (participants: Partial<Participant>[]): void => {
+    this.participantListObserver.publish(participants);
   };
 
   /**


### PR DESCRIPTION
This PR changes the `MEETING_PARTICIPANT_LIST_UPDATE` and `MEETING_PARTICIPANT_AMOUNT_UPDATE` events logic, previously this list was the real-time attendee list, now it is updated by meeting attendees. 