### PR TITLE
fix: wait user enter realtime to initialize video

### DIFF
--- a/__mocks__/realtime.mock.ts
+++ b/__mocks__/realtime.mock.ts
@@ -19,6 +19,7 @@ export const createRealtimeHistory = () => ({
 });
 
 export const ABLY_REALTIME_MOCK: AblyRealtimeService = {
+  isJoinedRoom: false,
   isLocalParticipantHost: true,
   setGather: jest.fn(),
   setHost: jest.fn(),

--- a/src/components/video/index.test.ts
+++ b/src/components/video/index.test.ts
@@ -62,6 +62,8 @@ jest.mock('../../services/event-bus', () => {
   return jest.fn().mockImplementation(() => EVENT_BUS_MOCK);
 });
 
+const REALTIME_MOCK = Object.assign({}, ABLY_REALTIME_MOCK, { isJoinedRoom: true });
+
 describe('VideoComponent', () => {
   let VideoComponentInstance: VideoComponent;
 
@@ -69,8 +71,9 @@ describe('VideoComponent', () => {
     jest.clearAllMocks();
 
     VideoComponentInstance = new VideoComponent();
+
     VideoComponentInstance.attach({
-      realtime: ABLY_REALTIME_MOCK,
+      realtime: REALTIME_MOCK,
       localParticipant: MOCK_LOCAL_PARTICIPANT,
       group: MOCK_GROUP,
       config: MOCK_CONFIG,
@@ -82,6 +85,22 @@ describe('VideoComponent', () => {
     VideoComponentInstance.detach();
   });
 
+  test('should not initialize video if realtime is not joined room', () => {
+    VideoComponentInstance.detach();
+
+    VideoComponentInstance = new VideoComponent();
+
+    VideoComponentInstance.attach({
+      realtime: ABLY_REALTIME_MOCK,
+      localParticipant: MOCK_LOCAL_PARTICIPANT,
+      group: MOCK_GROUP,
+      config: MOCK_CONFIG,
+      eventBus: EVENT_BUS_MOCK,
+    });
+
+    expect(VIDEO_MANAGER_MOCK.start).not.toHaveBeenCalled();
+  });
+
   test('should not show avatar settings if local participant has avatar', () => {
     VideoComponentInstance.detach();
 
@@ -90,7 +109,7 @@ describe('VideoComponent', () => {
     });
 
     VideoComponentInstance.attach({
-      realtime: ABLY_REALTIME_MOCK,
+      realtime: REALTIME_MOCK,
       localParticipant: {
         ...MOCK_LOCAL_PARTICIPANT,
         avatar: MOCK_AVATAR,

--- a/src/components/video/index.test.ts
+++ b/src/components/video/index.test.ts
@@ -62,6 +62,8 @@ jest.mock('../../services/event-bus', () => {
   return jest.fn().mockImplementation(() => EVENT_BUS_MOCK);
 });
 
+jest.useFakeTimers();
+
 const REALTIME_MOCK = Object.assign({}, ABLY_REALTIME_MOCK, { isJoinedRoom: true });
 
 describe('VideoComponent', () => {
@@ -98,7 +100,14 @@ describe('VideoComponent', () => {
       eventBus: EVENT_BUS_MOCK,
     });
 
+    VideoComponentInstance['start'] = jest.fn(VideoComponentInstance['start']);
+    VideoComponentInstance['logger'].log = jest.fn();
+
     expect(VIDEO_MANAGER_MOCK.start).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1000);
+
+    expect(VideoComponentInstance['start']).toHaveBeenCalledTimes(1);
   });
 
   test('should not show avatar settings if local participant has avatar', () => {

--- a/src/components/video/index.ts
+++ b/src/components/video/index.ts
@@ -455,6 +455,8 @@ export class VideoComponent extends BaseComponent {
    * @returns {void}
    * */
   private onRoomInfoUpdated = (room: AblyRealtimeData): void => {
+    if (!room) return;
+
     this.logger.log('video component @ on room info updated', room);
     const { isGridModeEnable, followParticipantId, gather, drawing, transcript, hostClientId } =
       room;
@@ -485,7 +487,7 @@ export class VideoComponent extends BaseComponent {
   private onRealtimeParticipantsDidChange = (
     participants: Record<string, AblyParticipant>,
   ): void => {
-    if (!this.videoManager) return;
+    if (!this.videoManager || !participants) return;
 
     this.logger.log('video component @ on participants did change', participants);
 

--- a/src/components/video/index.ts
+++ b/src/components/video/index.ts
@@ -34,7 +34,7 @@ export class VideoComponent extends BaseComponent {
   private participantToFrameList: ParticipandToFrame[] = [];
   private participantsOnMeeting: Partial<Participant>[] = [];
 
-  private videoManager: VideoConfereceManager;
+  private videoManager?: VideoConfereceManager;
   private connectionService: ConnectionService;
   private browserService: BrowserService;
 
@@ -62,14 +62,25 @@ export class VideoComponent extends BaseComponent {
    * @description start video component
    * @returns {void}
    */
-  protected start(): void {
+  protected start = (): void => {
     this.logger.log('video component @ start');
+
+    if (!this.realtime.isJoinedRoom) {
+      this.logger.log('video component @ start - not joined yet');
+
+      setTimeout(() => {
+        this.logger.log('video component @ start - retrying');
+        this.start();
+      }, 1000);
+
+      return;
+    }
 
     this.publish(MeetingEvent.MEETING_START);
 
     this.suscribeToRealtimeEvents();
     this.startVideo();
-  }
+  };
 
   /**
    * @function destroy
@@ -84,7 +95,7 @@ export class VideoComponent extends BaseComponent {
     this.unsubscribeFromRealtimeEvents();
     this.unsubscribeFromVideoEvents();
 
-    this.videoManager.leave();
+    this.videoManager?.leave();
     this.connectionService.removeListeners();
   }
 
@@ -153,19 +164,19 @@ export class VideoComponent extends BaseComponent {
   private unsubscribeFromVideoEvents = (): void => {
     this.logger.log('video component @ unsubscribe from video events');
 
-    this.videoManager.meetingConnectionObserver.unsubscribe(
+    this.videoManager?.meetingConnectionObserver.unsubscribe(
       this.connectionService.updateMeetingConnectionStatus,
     );
-    this.videoManager.participantListObserver.unsubscribe(this.onParticipantListUpdate);
-    this.videoManager.waitingForHostObserver.unsubscribe(this.onWaitingForHost);
-    this.videoManager.frameSizeObserver.unsubscribe(this.onFrameSizeDidChange);
-    this.videoManager.meetingStateObserver.unsubscribe(this.onMeetingStateChange);
-    this.videoManager.frameStateObserver.unsubscribe(this.onFrameStateChange);
-    this.videoManager.realtimeEventsObserver.unsubscribe(this.onRealtimeEventFromFrame);
-    this.videoManager.participantJoinedObserver.unsubscribe(this.onParticipantJoined);
-    this.videoManager.participantLeftObserver.unsubscribe(this.onParticipantLeft);
-    this.videoManager.sameAccountErrorObserver.unsubscribe(this.onSameAccountError);
-    this.videoManager.devicesObserver.unsubscribe(this.onDevicesChange);
+    this.videoManager?.participantListObserver.unsubscribe(this.onParticipantListUpdate);
+    this.videoManager?.waitingForHostObserver.unsubscribe(this.onWaitingForHost);
+    this.videoManager?.frameSizeObserver.unsubscribe(this.onFrameSizeDidChange);
+    this.videoManager?.meetingStateObserver.unsubscribe(this.onMeetingStateChange);
+    this.videoManager?.frameStateObserver.unsubscribe(this.onFrameStateChange);
+    this.videoManager?.realtimeEventsObserver.unsubscribe(this.onRealtimeEventFromFrame);
+    this.videoManager?.participantJoinedObserver.unsubscribe(this.onParticipantJoined);
+    this.videoManager?.participantLeftObserver.unsubscribe(this.onParticipantLeft);
+    this.videoManager?.sameAccountErrorObserver.unsubscribe(this.onSameAccountError);
+    this.videoManager?.devicesObserver.unsubscribe(this.onDevicesChange);
   };
 
   /**
@@ -365,6 +376,9 @@ export class VideoComponent extends BaseComponent {
     this.publish(MeetingEvent.MEETING_PARTICIPANT_JOINED, participant);
     this.publish(MeetingEvent.MY_PARTICIPANT_JOINED, participant);
 
+    this.onRealtimeParticipantsDidChange(this.realtime.getParticipants);
+    this.onRoomInfoUpdated(this.realtime.roomProperties);
+
     if (this.videoConfig.canUseDefaultAvatars) {
       this.realtime.updateMyProperties({
         avatar: participant.avatar,
@@ -442,7 +456,8 @@ export class VideoComponent extends BaseComponent {
    * */
   private onRoomInfoUpdated = (room: AblyRealtimeData): void => {
     this.logger.log('video component @ on room info updated', room);
-    const { isGridModeEnable, followParticipantId, gather, drawing, transcript } = room;
+    const { isGridModeEnable, followParticipantId, gather, drawing, transcript, hostClientId } =
+      room;
 
     this.videoManager.publishMessageToFrame(
       RealtimeEvent.REALTIME_GRID_MODE_CHANGE,
@@ -454,6 +469,7 @@ export class VideoComponent extends BaseComponent {
       followParticipantId,
     );
     this.videoManager.publishMessageToFrame(RealtimeEvent.REALTIME_TRANSCRIPT_CHANGE, transcript);
+    this.videoManager.publishMessageToFrame(RealtimeEvent.REALTIME_HOST_CHANGE, hostClientId);
 
     if (this.realtime.hostClientId === this.localParticipant.id && gather) {
       this.realtime.setGather(false);
@@ -469,6 +485,8 @@ export class VideoComponent extends BaseComponent {
   private onRealtimeParticipantsDidChange = (
     participants: Record<string, AblyParticipant>,
   ): void => {
+    if (!this.videoManager) return;
+
     this.logger.log('video component @ on participants did change', participants);
 
     const participantList: ParticipandToFrame[] = Object.values(participants).map(


### PR DESCRIPTION
Implements recursion to wait to join the realtime room. It's necessary because videoconferencing depends on the realtime room state and realtime participants to initialize the meeting room.