### PR TITLE
refactor: add group name to send on activity

### DIFF
--- a/src/core/launcher/index.ts
+++ b/src/core/launcher/index.ts
@@ -4,6 +4,7 @@ import { ParticipantEvent, RealtimeEvent } from '../../common/types/events.types
 import { Group, Participant } from '../../common/types/participant.types';
 import { Logger } from '../../common/utils';
 import { BaseComponent } from '../../components/base';
+import ApiService from '../../services/api';
 import config from '../../services/config';
 import { EventBus } from '../../services/event-bus';
 import { PubSub } from '../../services/pubsub';
@@ -12,7 +13,6 @@ import { AblyParticipant, RealtimeMessage } from '../../services/realtime/ably/t
 import { HostObserverCallbackResponse } from '../../services/realtime/base/types';
 
 import { DefaultLauncher, LauncherFacade, LauncherOptions } from './types';
-import ApiService from "../../services/api";
 
 export class Launcher implements DefaultLauncher {
   private readonly shouldKickParticipantsOnHostLeave: boolean;
@@ -62,7 +62,7 @@ export class Launcher implements DefaultLauncher {
       config: config.configuration,
       eventBus: this.eventBus,
     });
-    ApiService.sendActivity(this.participant.id, this.group.id, component.name)
+    ApiService.sendActivity(this.participant.id, this.group.id, this.group.name, component.name);
   };
 
   /**

--- a/src/services/api/index.test.ts
+++ b/src/services/api/index.test.ts
@@ -79,11 +79,11 @@ describe('ApiService', () => {
 
   describe('sendActivity', () => {
     test('should return any message', async () => {
-
-      const userId = 'user-id'
-      const groupId = 'group-id'
-      const product = 'video-component'
-      const response = await ApiService.sendActivity(userId, groupId, product);
+      const userId = 'user-id';
+      const groupId = 'group-id';
+      const groupName = 'group-name';
+      const product = 'video-component';
+      const response = await ApiService.sendActivity(userId, groupId, groupName, product);
 
       expect(response).toEqual({ message: 'any message' });
     });

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -1,5 +1,5 @@
 import { doRequest } from '../../common/utils';
-import config from "../config";
+import config from '../config';
 
 export default class ApiService {
   static createUrl(baseUrl: string, path: string): string {
@@ -25,7 +25,7 @@ export default class ApiService {
     return message;
   }
 
-  static async sendActivity(userId: string, groupId: string, product: string) {
+  static async sendActivity(userId: string, groupId: string, groupName: string, product: string) {
     const path = '/activity';
     const baseUrl = config.get<string>('apiUrl');
     const meetingId = config.get<string>('roomId');
@@ -33,10 +33,11 @@ export default class ApiService {
     const url = this.createUrl(baseUrl, path);
     const body = {
       groupId,
+      groupName,
       meetingId,
       product,
-      userId
-    }
+      userId,
+    };
     return doRequest(url, 'POST', body, { apikey });
   }
 }


### PR DESCRIPTION
Add group name to send on activity. The amplitude new monthly active user need this field value: workspace_name