### PR TITLE
feat: realtime component

### DIFF
--- a/lib.md
+++ b/lib.md
@@ -2,11 +2,15 @@
 
 ```ts
 import { SuperViz } from '@superviz/sdk';
-import { VideoComponent } from '@superviz/sdk/components/video.ts';
-import { CommentsComponent, CanvasAdapter } from '@superviz/sdk/components/comments.ts';
+import {
+  VideoComponent,
+  Realtime,
+  PresenceComponent,
+  CommentsComponent,
+  CanvasAdapter,
+} from '@superviz/sdk/components';
 import { Presence3D, CommentsAdapter } from '@superviz/matterport';
 import { Presence3D, CommentsAdapter } from '@superviz/three';
-import { PresenceComponent } from '@superviz/sdk/components/presence.ts';
 
 const SuperViz = await Manager(DEVELOPER_KEY, {
   roomId: this.roomId,
@@ -21,6 +25,10 @@ const SuperViz = await Manager(DEVELOPER_KEY, {
 });
 
 const video = new VideoComponent();
+SuperViz.addComponent(video);
+
+const realtime = new Realtime();
+SuperViz.addComponent(realtime);
 
 const mpPresence = new Presence3D(mpInstance);
 SuperViz.addComponent(mpPresence);
@@ -31,20 +39,15 @@ const comments = new CommentsComponent(canvasAdapter);
 SuperViz.addComponent(comments);
 
 // Initialize coments with matterport 3d component
-const canvasAdapter = new CommentsAdapter(mpInstance);
-const comments = new CommentsComponent(canvasAdapter);
+const mpCommentsAdapter = new CommentsAdapter(mpInstance);
+const comments = new CommentsComponent(mpCommentsAdapter);
 SuperViz.addComponent(comments);
-
-// const mpCommentsAdapter = new CommentsAdapter(mpInstance);
-
-// add configs
-SuperViz.addComponent(video);
 SuperViz.addComponent(mpPresence);
 
 // PubSub
-SuperViz.unsubscribe('presence-updated', () => {});
-SuperViz.subscribe('presence-updated', () => {});
-SuperViz.publish('presence-updated', {});
+realtime.unsubscribe('presence-updated', () => {});
+realtime.subscribe('presence-updated', () => {});
+realtime.publish('presence-updated', {});
 
 // removing component
 SuperViz.removeComponent(mpPresence);

--- a/src/common/types/cdn.types.ts
+++ b/src/common/types/cdn.types.ts
@@ -1,4 +1,9 @@
-import { PresenceMouseComponent, VideoComponent } from '../../components';
+import {
+  CommentsComponent,
+  PresenceMouseComponent,
+  Realtime,
+  VideoComponent,
+} from '../../components';
 import { LauncherFacade } from '../../core/launcher/types';
 
 import {
@@ -23,4 +28,6 @@ export interface SuperVizCdn {
   ParticipantEvent: typeof ParticipantEvent;
   VideoComponent: typeof VideoComponent;
   PresenceMouseComponent: typeof PresenceMouseComponent;
+  Realtime: typeof Realtime;
+  CommentsComponent: typeof CommentsComponent;
 }

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -1,5 +1,7 @@
 import doRequest from './do-request';
 import { Logger } from './logger';
+import { Observable } from './observable';
 import { Observer } from './observer';
+import sleep from './sleep';
 
-export { Logger, doRequest, Observer };
+export { Logger, doRequest, Observer, sleep, Observable };

--- a/src/common/utils/observable.test.ts
+++ b/src/common/utils/observable.test.ts
@@ -1,0 +1,62 @@
+import { Logger } from './logger';
+import { Observable } from './observable';
+
+class DummyObserverClass extends Observable {
+  protected logger: Logger;
+
+  constructor() {
+    super();
+
+    this.logger = new Logger('@superviz/sdk/dummie-observer-class');
+  }
+}
+
+describe('observer class', () => {
+  let DummyObserverClassInstance: DummyObserverClass;
+
+  beforeEach(() => {
+    DummyObserverClassInstance = new DummyObserverClass();
+  });
+
+  test('should subscribe to the event component with success', () => {
+    const callback = jest.fn();
+
+    expect(DummyObserverClassInstance.subscribe).toBeDefined();
+
+    DummyObserverClassInstance.subscribe('test', callback);
+
+    DummyObserverClassInstance['publish']('test', 'test');
+
+    expect(callback).toBeCalledWith('test');
+  });
+
+  test('should unsubscribe to the event component with success', () => {
+    const callback = jest.fn();
+
+    expect(DummyObserverClassInstance.subscribe).toBeDefined();
+
+    DummyObserverClassInstance.subscribe('test', callback);
+
+    DummyObserverClassInstance['publish']('test', 'test');
+
+    expect(callback).toBeCalledWith('test');
+
+    DummyObserverClassInstance.unsubscribe('test');
+
+    DummyObserverClassInstance['publish']('test', 'test');
+
+    expect(callback).toBeCalledTimes(1);
+  });
+
+  test('should skip unsubscribe if the event is not subscribed', () => {
+    expect(DummyObserverClassInstance.subscribe).toBeDefined();
+
+    DummyObserverClassInstance.unsubscribe('test');
+  });
+
+  test('should skip publish if the event is not subscribed', () => {
+    expect(DummyObserverClassInstance.subscribe).toBeDefined();
+
+    DummyObserverClassInstance['publish']('test', 'test');
+  });
+});

--- a/src/common/utils/observable.ts
+++ b/src/common/utils/observable.ts
@@ -1,0 +1,54 @@
+import { Logger } from './logger';
+import { Observer } from './observer';
+
+export abstract class Observable {
+  protected abstract logger: Logger;
+  protected observers: Record<string, Observer> = {};
+
+  /**
+   * @function subscribe
+   * @description Subscribe to an event
+   * @param type - event type
+   * @param listener - event callback
+   * @returns {void}
+   */
+  public subscribe = (type: string, listener: Function): void => {
+    this.logger.log(`subscribed to ${type} event`);
+
+    if (!this.observers[type]) {
+      this.observers[type] = new Observer({ logger: this.logger });
+    }
+
+    this.observers[type].subscribe(listener);
+  };
+
+  /**
+   * @function unsubscribe
+   * @description Unsubscribe from an event
+   * @param type - event type
+   * @returns {void}
+   */
+  public unsubscribe = (type: string, callback?: (data: unknown) => void): void => {
+    this.logger.log(`unsubscribed from ${type} event`);
+
+    if (!this.observers[type]) return;
+
+    this.observers[type].reset();
+    delete this.observers[type];
+  };
+
+  /**
+   * @function publish
+   * @description Publish an event to client
+   * @param type - event type
+   * @param data - event data
+   * @returns {void}
+   */
+  protected publish = (type: string, data?: unknown): void => {
+    const hasListenerRegistered = type in this.observers;
+
+    if (!hasListenerRegistered) return;
+
+    this.observers[type].publish(data);
+  };
+}

--- a/src/components/base/index.test.ts
+++ b/src/components/base/index.test.ts
@@ -153,48 +153,4 @@ describe('BaseComponent', () => {
       expect(DummyComponentInstance['logger'].log).toBeCalled();
     });
   });
-
-  describe('subscribe', () => {
-    test('should subscribe to the event component with success', () => {
-      const callback = jest.fn();
-
-      expect(DummyComponentInstance.subscribe).toBeDefined();
-
-      DummyComponentInstance.subscribe('test', callback);
-
-      DummyComponentInstance['publish']('test', 'test');
-
-      expect(callback).toBeCalledWith('test');
-    });
-
-    test('should unsubscribe to the event component with success', () => {
-      const callback = jest.fn();
-
-      expect(DummyComponentInstance.subscribe).toBeDefined();
-
-      DummyComponentInstance.subscribe('test', callback);
-
-      DummyComponentInstance['publish']('test', 'test');
-
-      expect(callback).toBeCalledWith('test');
-
-      DummyComponentInstance.unsubscribe('test');
-
-      DummyComponentInstance['publish']('test', 'test');
-
-      expect(callback).toBeCalledTimes(1);
-    });
-
-    test('should skip unsubscribe if the event is not subscribed', () => {
-      expect(DummyComponentInstance.subscribe).toBeDefined();
-
-      DummyComponentInstance.unsubscribe('test');
-    });
-
-    test('should skip publish if the event is not subscribed', () => {
-      expect(DummyComponentInstance.subscribe).toBeDefined();
-
-      DummyComponentInstance['publish']('test', 'test');
-    });
-  });
 });

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -1,5 +1,5 @@
 import { Group, Participant } from '../../common/types/participant.types';
-import { Logger, Observer } from '../../common/utils';
+import { Logger, Observer, Observable } from '../../common/utils';
 import config from '../../services/config';
 import { EventBus } from '../../services/event-bus';
 import { AblyRealtimeService } from '../../services/realtime';
@@ -7,9 +7,7 @@ import { ComponentNames } from '../types';
 
 import { DefaultAttachComponentOptions } from './types';
 
-export abstract class BaseComponent {
-  private observers: Record<string, Observer> = {};
-
+export abstract class BaseComponent extends Observable {
   public abstract name: ComponentNames;
   protected abstract logger: Logger;
   protected localParticipant: Participant;
@@ -77,53 +75,6 @@ export abstract class BaseComponent {
     this.isAttached = false;
 
     Object.keys(this.observers).forEach((type) => this.unsubscribe(type));
-  };
-
-  /**
-   * @function subscribe
-   * @description Subscribe to an event
-   * @param type - event type
-   * @param listener - event callback
-   * @returns {void}
-   */
-  public subscribe = (type: string, listener: Function): void => {
-    this.logger.log(`subscribed to ${type} event`);
-
-    if (!this.observers[type]) {
-      this.observers[type] = new Observer({ logger: this.logger });
-    }
-
-    this.observers[type].subscribe(listener);
-  };
-
-  /**
-   * @function unsubscribe
-   * @description Unsubscribe from an event
-   * @param type - event type
-   * @returns {void}
-   */
-  public unsubscribe = (type: string): void => {
-    this.logger.log(`unsubscribed from ${type} event`);
-
-    if (!this.observers[type]) return;
-
-    this.observers[type].reset();
-    delete this.observers[type];
-  };
-
-  /**
-   * @function publish
-   * @description Publish an event to client
-   * @param type - event type
-   * @param data - event data
-   * @returns {void}
-   */
-  protected publish = (type: string, data?: unknown): void => {
-    const hasListenerRegistered = type in this.observers;
-
-    if (!hasListenerRegistered) return;
-
-    this.observers[type].publish(data);
   };
 
   protected abstract destroy(): void;

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -1,5 +1,5 @@
 import { Group, Participant } from '../../common/types/participant.types';
-import { Logger, Observer, Observable } from '../../common/utils';
+import { Logger, Observable } from '../../common/utils';
 import config from '../../services/config';
 import { EventBus } from '../../services/event-bus';
 import { AblyRealtimeService } from '../../services/realtime';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,3 +2,4 @@ export { CommentsComponent } from './comments';
 export { CanvasPinAdapter } from './comments/canvas-pin-adapter';
 export { VideoComponent } from './video';
 export { PresenceMouseComponent } from './presence-mouse';
+export { Realtime } from './realtime';

--- a/src/components/realtime/index.test.ts
+++ b/src/components/realtime/index.test.ts
@@ -1,0 +1,70 @@
+import { MOCK_CONFIG } from '../../../__mocks__/config.mock';
+import { EVENT_BUS_MOCK } from '../../../__mocks__/event-bus.mock';
+import { MOCK_GROUP, MOCK_LOCAL_PARTICIPANT } from '../../../__mocks__/participants.mock';
+import { ABLY_REALTIME_MOCK } from '../../../__mocks__/realtime.mock';
+
+import { Realtime } from '.';
+
+const PUB_SUB_MOCK = {
+  destroy: jest.fn(),
+  subscribe: jest.fn(),
+  unsubscribe: jest.fn(),
+  publish: jest.fn(),
+  fetchHistory: jest.fn(),
+  publishEventToClient: jest.fn(),
+};
+
+jest.mock('../../services/pubsub', () => ({
+  PubSub: jest.fn().mockImplementation(() => PUB_SUB_MOCK),
+}));
+
+describe('realtime component', () => {
+  let RealtimeComponentInstance: Realtime;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    RealtimeComponentInstance = new Realtime();
+    RealtimeComponentInstance.attach({
+      realtime: Object.assign({}, ABLY_REALTIME_MOCK, { isJoinedRoom: true }),
+      localParticipant: MOCK_LOCAL_PARTICIPANT,
+      group: MOCK_GROUP,
+      config: MOCK_CONFIG,
+      eventBus: EVENT_BUS_MOCK,
+    });
+  });
+
+  test('should be subscribe to event', () => {
+    const callback = jest.fn();
+
+    RealtimeComponentInstance.subscribe('test', callback);
+
+    expect(PUB_SUB_MOCK.subscribe).toHaveBeenCalledWith('test', callback);
+  });
+
+  test('should be unsubscribe from event', () => {
+    const callback = jest.fn();
+
+    RealtimeComponentInstance.unsubscribe('test', callback);
+
+    expect(PUB_SUB_MOCK.unsubscribe).toHaveBeenCalledWith('test', callback);
+  });
+
+  test('should be publish event to realtime', () => {
+    RealtimeComponentInstance.publish('test', 'test');
+
+    expect(PUB_SUB_MOCK.publish).toHaveBeenCalledWith('test', 'test');
+  });
+
+  test('should be fetch history', async () => {
+    RealtimeComponentInstance.fetchHistory('test');
+
+    expect(PUB_SUB_MOCK.fetchHistory).toHaveBeenCalledWith('test');
+  });
+
+  test('should destroy pubsub when destroy realtime component', () => {
+    RealtimeComponentInstance.detach();
+
+    expect(PUB_SUB_MOCK.destroy).toHaveBeenCalled();
+  });
+});

--- a/src/components/realtime/index.ts
+++ b/src/components/realtime/index.ts
@@ -1,0 +1,73 @@
+import { Logger } from '../../common/utils';
+import { PubSub } from '../../services/pubsub';
+import { RealtimeMessage } from '../../services/realtime/ably/types';
+import { BaseComponent } from '../base';
+import { ComponentNames } from '../types';
+
+export class Realtime extends BaseComponent {
+  private pubsub: PubSub;
+
+  protected logger: Logger;
+  public name: ComponentNames;
+
+  constructor() {
+    super();
+
+    this.name = ComponentNames.REALTIME;
+    this.logger = new Logger('@superviz/sdk/realtime-component');
+  }
+
+  protected destroy(): void {
+    this.logger.log('destroyed');
+    this.pubsub.destroy();
+  }
+
+  protected start(): void {
+    this.logger.log('started');
+    this.pubsub = new PubSub(this.realtime);
+  }
+
+  /**
+   * @function publish
+   * @description Publish an event
+   * @param type - event type
+   * @param data - event data
+   * @returns {void}
+   */
+  public publish = (event: string, data?: unknown): void => {
+    this.pubsub.publish(event, data);
+  };
+
+  /**
+   * @function subscribe
+   * @description subscribe to event
+   * @param event - event name
+   * @param callback - callback function
+   * @returns {void}
+   */
+  public subscribe = (event: string, callback: (data: unknown) => void): void => {
+    this.pubsub.subscribe(event, callback);
+  };
+
+  /**
+   * @function unsubscribe
+   * @description - unsubscribe from event
+   * @param event - event name
+   * @param callback - callback function
+   * @returns {void}
+   */
+  public unsubscribe = (event: string, callback?: (data: unknown) => void): void => {
+    this.pubsub.unsubscribe(event, callback);
+  };
+
+  /**
+   * @function fetchSyncClientProperty
+   * @description get realtime client data history
+   * @returns {RealtimeMessage | Record<string, RealtimeMessage>}
+   */
+  public fetchHistory(
+    eventName?: string,
+  ): Promise<RealtimeMessage | Record<string, RealtimeMessage>> {
+    return this.pubsub.fetchHistory(eventName);
+  }
+}

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -1,22 +1,23 @@
 export enum ComponentNames {
-    PRESENCE = 'presence',
-    VIDEO_CONFERENCE = 'videoConference',
-    COMMENTS = 'comments',
-    PRESENCE_MATTERPORT = 'presence3dMatterport',
-    PRESENCE_AUTODESK = 'presence3dAutodesk',
-    PRESENCE_THREEJS = 'presence3dThreejs',
-    COMMENTS_MATTERPORT = 'comments3dMatterport',
-    COMMENTS_AUTODESK = 'comments3dAutodesk',
-    COMMENTS_THREEJS = 'comments3dThreejs',
+  REALTIME = 'realtime',
+  PRESENCE = 'presence',
+  VIDEO_CONFERENCE = 'videoConference',
+  COMMENTS = 'comments',
+  PRESENCE_MATTERPORT = 'presence3dMatterport',
+  PRESENCE_AUTODESK = 'presence3dAutodesk',
+  PRESENCE_THREEJS = 'presence3dThreejs',
+  COMMENTS_MATTERPORT = 'comments3dMatterport',
+  COMMENTS_AUTODESK = 'comments3dAutodesk',
+  COMMENTS_THREEJS = 'comments3dThreejs',
 }
 
 export enum Presence3d {
-    'presence3dMatterport' = 'presence3d',
-    'presence3dAutodesk' = 'presence3d',
-    'presence3dThreejs' = 'presence3d',
+  'presence3dMatterport' = 'presence3d',
+  'presence3dAutodesk' = 'presence3d',
+  'presence3dThreejs' = 'presence3d',
 }
 export enum Comments3d {
-    'comments3dMatterport' = 'comments3d',
-    'comments3dAutodesk' = 'comments3d',
-    'comments3dThreejs' = 'comments3d',
+  'comments3dMatterport' = 'comments3d',
+  'comments3dAutodesk' = 'comments3d',
+  'comments3dThreejs' = 'comments3d',
 }

--- a/src/core/launcher/index.ts
+++ b/src/core/launcher/index.ts
@@ -2,6 +2,7 @@ import { isEqual } from 'lodash';
 
 import { ParticipantEvent, RealtimeEvent } from '../../common/types/events.types';
 import { Group, Participant } from '../../common/types/participant.types';
+import { Observable } from '../../common/utils';
 import { Logger } from '../../common/utils/logger';
 import { BaseComponent } from '../../components/base';
 import ApiService from '../../services/api';
@@ -15,20 +16,21 @@ import { HostObserverCallbackResponse } from '../../services/realtime/base/types
 
 import { DefaultLauncher, LauncherFacade, LauncherOptions } from './types';
 
-export class Launcher implements DefaultLauncher {
+export class Launcher extends Observable implements DefaultLauncher {
   private readonly shouldKickParticipantsOnHostLeave: boolean;
-  private readonly logger: Logger;
+  protected readonly logger: Logger;
 
   private participant: Participant;
   private group: Group;
 
   private readonly realtime: AblyRealtimeService;
-  private readonly pubsub: PubSub;
   private readonly eventBus: EventBus = new EventBus();
 
   private participants: Participant[] = [];
 
   constructor({ participant, group, shouldKickParticipantsOnHostLeave }: LauncherOptions) {
+    super();
+
     this.shouldKickParticipantsOnHostLeave = shouldKickParticipantsOnHostLeave ?? true;
     this.participant = participant as Participant;
     this.group = group;
@@ -39,8 +41,6 @@ export class Launcher implements DefaultLauncher {
       config.get<string>('ablyKey'),
     );
 
-    // events with realtime
-    this.pubsub = new PubSub(this.realtime);
     // internal events without realtime
     this.eventBus = new EventBus();
 
@@ -82,54 +82,6 @@ export class Launcher implements DefaultLauncher {
    */
   public removeComponent = (component: BaseComponent): void => {
     component.detach();
-  };
-
-  /**
-   * @function subscribeToPubSubEvent
-   * @description subscribe to pubsub event
-   * @param event - event name
-   * @param callback - callback function
-   * @returns {void}
-   */
-  public subscribeToPubSubEvent = (event: string, callback: (data: unknown) => void): void => {
-    this.logger.log('launcher service @ subscribeToPubSubEvent');
-    this.pubsub.subscribe(event, callback);
-  };
-
-  /**
-   * @function unsubscribeFromPubSubEvent
-   * @description unsubscribe from pubsub event
-   * @param event - event name
-   * @param callback - callback function
-   * @returns {void}
-   */
-  public unsubscribeFromPubSubEvent = (event: string, callback: (data: unknown) => void): void => {
-    this.logger.log('launcher service @ unsubscribeFromPubSubEvent');
-    this.pubsub.unsubscribe(event, callback);
-  };
-
-  /**
-   * @function publishToPubSubEvent
-   * @description publish to pubsub event
-   * @param event - event name
-   * @param data - data to publish
-   * @returns {void}
-   */
-  public publishToPubSubEvent = (event: string, data: unknown): void => {
-    this.logger.log('launcher service @ publishToPubSubEvent');
-    this.pubsub.publish(event, data);
-  };
-
-  /**
-   * @function fetchPubSubHistory
-   * @description fetch pubsub history
-   * @param eventName - event name
-   * @returns realtime message or realtime history
-   */
-  public fetchPubSubHistory = (
-    eventName?: string,
-  ): Promise<RealtimeMessage | Record<string, RealtimeMessage>> => {
-    return this.pubsub.fetchHistory(eventName);
   };
 
   /**
@@ -193,14 +145,14 @@ export class Launcher implements DefaultLauncher {
 
     if (!isEqual(this.participants, participantList)) {
       this.participants = participantList;
-      this.pubsub.publishEventToClient(ParticipantEvent.LIST_UPDATED, participantList);
+      this.publish(ParticipantEvent.LIST_UPDATED, participantList);
 
       this.logger.log('Publishing ParticipantEvent.LIST_UPDATED', participantList);
     }
 
     if (localParticipant && !isEqual(this.participant, localParticipant)) {
       this.participant = localParticipant;
-      this.pubsub.publishEventToClient(ParticipantEvent.LOCAL_UPDATED, localParticipant);
+      this.publish(ParticipantEvent.LOCAL_UPDATED, localParticipant);
 
       this.logger.log('Publishing ParticipantEvent.UPDATED', localParticipant);
     }
@@ -223,11 +175,11 @@ export class Launcher implements DefaultLauncher {
 
     if (participant.id === this.participant.id) {
       this.logger.log('launcher service @ onParticipantJoined - local participant joined');
-      this.pubsub.publishEventToClient(ParticipantEvent.LOCAL_JOINED, participant);
+      this.publish(ParticipantEvent.LOCAL_JOINED, participant);
     }
 
     this.logger.log('launcher service @ onParticipantJoined - participant joined', participant);
-    this.pubsub.publishEventToClient(ParticipantEvent.JOINED, participant);
+    this.publish(ParticipantEvent.JOINED, participant);
   };
 
   /**
@@ -247,11 +199,11 @@ export class Launcher implements DefaultLauncher {
 
     if (participant.id === this.participant.id) {
       this.logger.log('launcher service @ onParticipantLeave - local participant left');
-      this.pubsub.publishEventToClient(ParticipantEvent.LOCAL_LEFT, participant);
+      this.publish(ParticipantEvent.LOCAL_LEFT, participant);
     }
 
     this.logger.log('launcher service @ onParticipantLeave - participant left', participant);
-    this.pubsub.publishEventToClient(ParticipantEvent.LEFT, participant);
+    this.publish(ParticipantEvent.LEFT, participant);
   };
 
   /**
@@ -266,7 +218,8 @@ export class Launcher implements DefaultLauncher {
     });
 
     if (this.realtime.isLocalParticipantHost) {
-      this.publishToPubSubEvent(RealtimeEvent.REALTIME_HOST_CHANGE, newHost);
+      this.realtime.setSyncProperty(RealtimeEvent.REALTIME_HOST_CHANGE, newHost);
+      this.publish(RealtimeEvent.REALTIME_HOST_CHANGE, newHost);
     }
   };
 
@@ -280,10 +233,10 @@ export class Launcher implements DefaultLauncher {
     this.logger.log('launcher service @ onHostAvailabilityChange');
 
     if (isHostAvailable) {
-      this.pubsub.publishEventToClient(RealtimeEvent.REALTIME_HOST_AVAILABLE);
+      this.publish(RealtimeEvent.REALTIME_HOST_AVAILABLE);
       return;
     }
-    this.pubsub.publishEventToClient(RealtimeEvent.REALTIME_NO_HOST_AVAILABLE);
+    this.publish(RealtimeEvent.REALTIME_NO_HOST_AVAILABLE);
   };
 }
 
@@ -297,10 +250,8 @@ export default (options: LauncherOptions): LauncherFacade => {
   const launcher = new Launcher(options);
 
   return {
-    subscribe: launcher.subscribeToPubSubEvent,
-    unsubscribe: launcher.unsubscribeFromPubSubEvent,
-    publish: launcher.publishToPubSubEvent,
-    fetchHistory: launcher.fetchPubSubHistory,
+    subscribe: launcher.subscribe,
+    unsubscribe: launcher.unsubscribe,
     addComponent: launcher.addComponent,
     removeComponent: launcher.removeComponent,
   };

--- a/src/core/launcher/index.ts
+++ b/src/core/launcher/index.ts
@@ -9,9 +9,8 @@ import ApiService from '../../services/api';
 import config from '../../services/config';
 import { EventBus } from '../../services/event-bus';
 import LimitsService from '../../services/limits';
-import { PubSub } from '../../services/pubsub';
 import { AblyRealtimeService } from '../../services/realtime';
-import { AblyParticipant, RealtimeMessage } from '../../services/realtime/ably/types';
+import { AblyParticipant } from '../../services/realtime/ably/types';
 import { HostObserverCallbackResponse } from '../../services/realtime/base/types';
 
 import { DefaultLauncher, LauncherFacade, LauncherOptions } from './types';

--- a/src/core/launcher/types.ts
+++ b/src/core/launcher/types.ts
@@ -1,4 +1,5 @@
 import { SuperVizSdkOptions } from '../../common/types/sdk-options.types';
+import { Observable } from '../../common/utils';
 import { BaseComponent } from '../../components/base';
 import { PubSub } from '../../services/pubsub';
 
@@ -8,10 +9,8 @@ export interface LauncherOptions
   extends Omit<SuperVizSdkOptions, 'environment' | 'debug' | 'roomId'> {}
 
 export interface LauncherFacade {
-  subscribe: typeof PubSub.prototype.subscribe;
-  unsubscribe: typeof PubSub.prototype.unsubscribe;
-  publish: typeof PubSub.prototype.publish;
-  fetchHistory: typeof PubSub.prototype.fetchHistory;
+  subscribe: typeof Observable.prototype.subscribe;
+  unsubscribe: typeof Observable.prototype.unsubscribe;
   addComponent: (component: BaseComponent) => void;
   removeComponent: (component: BaseComponent) => void;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
   MeetingControlsEvent,
   ParticipantEvent,
 } from './common/types/events.types';
-import { VideoComponent, PresenceMouseComponent } from './components';
+import { VideoComponent, PresenceMouseComponent, Realtime, CommentsComponent } from './components';
 import init from './core';
 import './web-components';
 import './common/styles/global.css';
@@ -36,6 +36,8 @@ if (window) {
     ParticipantEvent,
     VideoComponent,
     PresenceMouseComponent,
+    Realtime,
+    CommentsComponent,
   };
 }
 

--- a/src/services/pubsub/index.test.ts
+++ b/src/services/pubsub/index.test.ts
@@ -1,3 +1,4 @@
+import { MOCK_OBSERVER_HELPER } from '../../../__mocks__/observer-helper.mock';
 import {
   ABLY_REALTIME_MOCK,
   createRealtimeHistory,
@@ -92,5 +93,12 @@ describe('PubSub', () => {
     expect(PubSubInstance.fetchHistory).toBeCalled();
     expect(ABLY_REALTIME_MOCK.fetchSyncClientProperty).toBeCalled();
     expect(history).toEqual(createRealtimeHistory());
+  });
+
+  test('should destroy service', () => {
+    PubSubInstance.destroy();
+
+    expect(PubSubInstance['observers']).toEqual(new Map());
+    expect(ABLY_REALTIME_MOCK.syncPropertiesObserver.unsubscribe).toHaveBeenCalled();
   });
 });

--- a/src/services/pubsub/index.ts
+++ b/src/services/pubsub/index.ts
@@ -89,6 +89,14 @@ export class PubSub {
     this.observers.get(event).publish(data);
   };
 
+  public destroy = (): void => {
+    this.logger.log('pubsub service @ destroy');
+
+    this.realtime.syncPropertiesObserver.unsubscribe(this.onSyncPropertiesChange);
+    this.observers.forEach((observer) => observer.destroy());
+    this.observers.clear();
+  };
+
   /**
    * @function onSyncPropertiesChange
    * @description - sync properties change handler

--- a/src/services/realtime/ably/index.ts
+++ b/src/services/realtime/ably/index.ts
@@ -504,11 +504,15 @@ export default class AblyRealtimeService extends RealtimeService implements Ably
    * @param {RealtimeMessage[]} data - The data to save as the latest state of the room.
    * @returns {void}
    */
-  private saveClientRoomState = (name: string, data: RealtimeMessage[]): void => {
-    this.clientRoomState[name] = data[data.length - 1];
+  private saveClientRoomState = async (name: string, data: RealtimeMessage[]): Promise<void> => {
+    const previusHistory = await this.fetchSyncClientProperty();
+
+    this.clientRoomState = Object.assign({}, previusHistory, {
+      [name]: data[data.length - 1],
+    });
     this.clientRoomStateChannel.publish('update', this.clientRoomState);
 
-    this.logger.log('REALTIME', 'setting new room state backup');
+    this.logger.log('REALTIME', 'setting new room state backup', this.clientRoomState);
   };
 
   /**


### PR DESCRIPTION
### Move real-time methods to dedicated component.

Before: 

```ts

const SuperViz = await Manager(DEVELOPER_KEY, {
  roomId: this.roomId,
  participant: {
    id: this.userId,
    name: 'John Doe',
    type: userType,
    avatar: {
      thumbnail: 'https://production.storage.superviz.com/readyplayerme/1.png',
    },
  },
});


// PubSub
SuperViz.unsubscribe('presence-updated', () => {});
SuperViz.subscribe('presence-updated', () => {});
SuperViz.publish('presence-updated', {});

```
After: 

```ts

const SuperViz = await Manager(DEVELOPER_KEY, {
  roomId: this.roomId,
  participant: {
    id: this.userId,
    name: 'John Doe',
    type: userType,
    avatar: {
      thumbnail: 'https://production.storage.superviz.com/readyplayerme/1.png',
    },
  },
});

const realtime = new Realtime();
SuperViz.addComponent(realtime);

// PubSub
realtime.unsubscribe('presence-updated', () => {});
realtime.subscribe('presence-updated', () => {});
realtime.publish('presence-updated', {});

```
 