### PR TITLE
feat: size buttons and scroll selected

### DIFF
--- a/src/web-components/comments/comments.ts
+++ b/src/web-components/comments/comments.ts
@@ -64,21 +64,20 @@ export class Comments extends WebComponentsBaseElement {
 
   protected render() {
     const containerClass = [this.open ? 'container' : 'container-close'].join(' ');
-    const poweredByFooter = html`
-    <div id="poweredby-footer" class="footer">
-    <div class="powered-by powered-by--horizontal">
-      <a href="https://superviz.com/" target="_blank" class="link">
-        <div class="">
-          Powered by
-          <img
-            width="48px"
-            height="8.86px"
-            src="https://production.cdn.superviz.com/static/superviz-gray-logo.svg"
-          />
-        </div>
-      </a>
-    </div>
-  </div>`;
+    const poweredByFooter = html` <div id="poweredby-footer" class="footer">
+      <div class="powered-by powered-by--horizontal">
+        <a href="https://superviz.com/" target="_blank" class="link">
+          <div class="">
+            Powered by
+            <img
+              width="48px"
+              height="8.86px"
+              src="https://production.cdn.superviz.com/static/superviz-gray-logo.svg"
+            />
+          </div>
+        </a>
+      </div>
+    </div>`;
 
     const htmlPoweredByContent = this.waterMarkState ? poweredByFooter : '';
 
@@ -99,7 +98,7 @@ export class Comments extends WebComponentsBaseElement {
           annotationFilter=${this.annotationFilter}
           class="content"
         ></superviz-comments-content>
-      ${htmlPoweredByContent}
+        ${htmlPoweredByContent}
       </div>
     `;
   }

--- a/src/web-components/comments/components/annotation-resolved.ts
+++ b/src/web-components/comments/components/annotation-resolved.ts
@@ -47,21 +47,21 @@ export class CommentsAnnotationResolved extends WebComponentsBaseElement {
   };
 
   private hide() {
-    this.emitEvent(
-      'hide',
-      {},
-      { bubbles: false, composed: false },
-    );
+    this.emitEvent('hide', {}, { bubbles: false, composed: false });
   }
 
   private undone() {
     this.isCanceled = true;
     this.hide();
 
-    this.emitEvent('undo-resolve', {
-      type: 'undo-resolve',
-      resolved: false,
-    }, { bubbles: false, composed: false });
+    this.emitEvent(
+      'undo-resolve',
+      {
+        type: 'undo-resolve',
+        resolved: false,
+      },
+      { bubbles: false, composed: false },
+    );
 
     clearTimeout(this.timeout);
   }
@@ -73,7 +73,11 @@ export class CommentsAnnotationResolved extends WebComponentsBaseElement {
     return html`
       <div class="annotation-resolved">
         <span class="text text-big sv-gray-700">You resolve this comment</span>
-        <button id="undone" @click=${this.undone} class="icon-button icon-button--clickable icon-button--medium">
+        <button
+          id="undone"
+          @click=${this.undone}
+          class="icon-button icon-button--clickable icon-button--medium"
+        >
           <superviz-icon name="undo" size="md"></superviz-icon>
         </button>
       </div>

--- a/src/web-components/comments/components/comment-item.test.ts
+++ b/src/web-components/comments/components/comment-item.test.ts
@@ -68,7 +68,7 @@ describe('CommentsCommentItem', () => {
     await element['updateComplete'];
 
     const resolveButton = element.shadowRoot!.querySelector(
-      '.comment-item__user > button',
+      '.comment-item__actions > button',
     ) as HTMLButtonElement;
 
     element.dispatchEvent = jest.fn();

--- a/src/web-components/comments/components/comment-item.ts
+++ b/src/web-components/comments/components/comment-item.ts
@@ -172,23 +172,25 @@ export class CommentsCommentItem extends WebComponentsBaseElement {
             <span class="text text-bold sv-gray-600">${this.username}</span>
             <span class="text text-small sv-gray-500">${humanizeDate(this.createdAt)}</span>
           </div>
-          <button
-            @click=${this.resolveAnnotation}
-            class="icon-button icon-button--clickable icon-button--xsmall ${isResolvable}"
-          >
-            <superviz-icon name=${resolveIcon} size="md"></superviz-icon>
-          </button>
-          <superviz-dropdown
-            options=${JSON.stringify(options)}
-            label="label"
-            returnTo="label"
-            position="bottom-right"
-            @selected=${dropdownOptionsHandler}
-          >
-            <button slot="dropdown" class="icon-button icon-button--clickable icon-button--small">
-              <superviz-icon name="more" size="sm"></superviz-icon>
+          <div class="comment-item__actions">
+            <button
+              @click=${this.resolveAnnotation}
+              class="icon-button icon-button--clickable icon-button--xsmall ${isResolvable}"
+            >
+              <superviz-icon name=${resolveIcon} size="md"></superviz-icon>
             </button>
-          </superviz-dropdown>
+            <superviz-dropdown
+              options=${JSON.stringify(options)}
+              label="label"
+              returnTo="label"
+              position="bottom-right"
+              @selected=${dropdownOptionsHandler}
+            >
+              <button slot="dropdown" class="icon-button icon-button--clickable icon-button--small">
+                <superviz-icon name="more" size="sm"></superviz-icon>
+              </button>
+            </superviz-dropdown>
+          </div>
         </div>
 
         <div class="comment-item__content">

--- a/src/web-components/comments/components/content.test.ts
+++ b/src/web-components/comments/components/content.test.ts
@@ -60,7 +60,7 @@ describe('CommentsContent', () => {
     await sleep();
 
     const annotationItem = element.shadowRoot?.querySelector('superviz-comments-annotation-item');
-
+    console.error(annotationItem);
     expect(annotationItem).toBeFalsy();
   });
 });

--- a/src/web-components/comments/components/content.ts
+++ b/src/web-components/comments/components/content.ts
@@ -22,6 +22,7 @@ export class CommentsContent extends WebComponentsBaseElement {
   declare annotations: Annotation[];
   declare selectedAnnotation: string;
   declare annotationFilter: AnnotationFilter;
+  private lastCommentId: string;
 
   static properties = {
     annotations: { type: Object },
@@ -33,6 +34,27 @@ export class CommentsContent extends WebComponentsBaseElement {
     const { uuid } = detail;
     this.selectedAnnotation = uuid;
   };
+
+  updated(changedProperties) {
+    super.updated(changedProperties);
+    this.updateComplete.then(() => {
+      const selectedAnnotation = this.shadowRoot.querySelector(
+        `[uuid='${this.selectedAnnotation}']`,
+      );
+
+      const isLastComment = this.lastCommentId === this.selectedAnnotation;
+      const offset = !isLastComment ? -150 : 0;
+      this.scrollBy(0, selectedAnnotation.getClientRects()[0].y + offset);
+
+      // "Add Comment" is not yet rendered in screen
+      // so we need an extra scroll to show it
+      if (isLastComment) {
+        setTimeout(() => {
+          this.scrollBy(0, selectedAnnotation.getClientRects()[0].y + offset);
+        }, 200);
+      }
+    });
+  }
 
   connectedCallback(): void {
     super.connectedCallback();
@@ -57,19 +79,23 @@ export class CommentsContent extends WebComponentsBaseElement {
 
     const isLastAnnotation = (index: number, resolved: boolean) => {
       if (resolved) return annotationsResolved?.length === index + 1;
+      this.lastCommentId = annotationsUnresolved[index].uuid;
       return annotationsUnresolved?.length === index + 1;
     };
 
     const annotationTemplate = (annotation: Annotation, index: number, resolved: boolean) => {
       const hasComments = annotation.comments.length > 0;
 
+      const isLast = isLastAnnotation(index, resolved);
+
       const annotationComments = hasComments
         ? html`
             <superviz-comments-annotation-item
               annotation=${JSON.stringify(annotation)}
               selected="${this.selectedAnnotation}"
-              ?isLastAnnotation=${isLastAnnotation(index, resolved)}
+              ?isLastAnnotation=${isLast}
               annotationFilter=${this.annotationFilter}
+              uuid=${annotation.uuid}
             >
             </superviz-comments-annotation-item>
           `

--- a/src/web-components/comments/components/content.ts
+++ b/src/web-components/comments/components/content.ts
@@ -41,16 +41,22 @@ export class CommentsContent extends WebComponentsBaseElement {
       const selectedAnnotation = this.shadowRoot.querySelector(
         `[uuid='${this.selectedAnnotation}']`,
       );
+      if (!selectedAnnotation) return;
 
       const isLastComment = this.lastCommentId === this.selectedAnnotation;
       const offset = !isLastComment ? -150 : 0;
-      this.scrollBy(0, selectedAnnotation.getClientRects()[0].y + offset);
+
+      const clientRects = selectedAnnotation.getClientRects()[0];
+
+      if (!clientRects) return;
+
+      this.scrollBy(0, clientRects.y + offset);
 
       // "Add Comment" is not yet rendered in screen
       // so we need an extra scroll to show it
       if (isLastComment) {
         setTimeout(() => {
-          this.scrollBy(0, selectedAnnotation.getClientRects()[0].y + offset);
+          this.scrollBy(0, clientRects.y + offset);
         }, 200);
       }
     });

--- a/src/web-components/comments/css/comment-item.style.ts
+++ b/src/web-components/comments/css/comment-item.style.ts
@@ -23,6 +23,19 @@ export const commentItemStyle = css`
     color: rgb(var(--sv-gray-500));
   }
 
+  .comment-item__actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .comment-item__actions superviz-dropdown,
+  .comment-item__actions button {
+    width: 25px;
+    height: 25px;
+    border-radius: 50%;
+  }
+
   .comment-item__user-details {
     display: flex;
     width: 100%;


### PR DESCRIPTION
Standardizes the size of the button of resolving comments and the one that opens a dropdown with "Edit" and "Delete" as options. Also gives more spacing between them.
![image](https://github.com/SuperViz/sdk/assets/111044527/e2ad6d4d-2adc-4537-82d5-bec67966e7e8)

Also, when a comment is selected, the container scrolls to show it.