### PR TITLE
fix: realtime history backup

### DIFF
--- a/src/services/limits/index.ts
+++ b/src/services/limits/index.ts
@@ -7,6 +7,6 @@ export default class LimitsService {
   static checkComponentLimit(name: ComponentNames): boolean {
     const componentName = Presence3d[name] ?? name;
     const limits = config.get<ComponentLimits>('limits');
-    return limits[componentName];
+    return limits?.[componentName] ?? false;
   }
 }

--- a/src/services/realtime/ably/index.ts
+++ b/src/services/realtime/ably/index.ts
@@ -1331,8 +1331,6 @@ export default class AblyRealtimeService extends RealtimeService implements Ably
   };
 
   public updatePresence3D = throttle((data: ParticipantInfo): void => {
-    console.trace('update');
-
     const participant = Object.assign({}, this.participantsOn3d[data.id]?.data ?? {}, data);
 
     this.participantsOn3d[data.id] = {
@@ -1342,8 +1340,6 @@ export default class AblyRealtimeService extends RealtimeService implements Ably
         ...this.participants[participant.id]?.data,
       },
     };
-
-    console.log('updatePresence3D', this.participantsOn3d[data.id]);
 
     if (!this.presence3DChannel) return;
 

--- a/src/services/realtime/ably/index.ts
+++ b/src/services/realtime/ably/index.ts
@@ -528,7 +528,9 @@ export default class AblyRealtimeService extends RealtimeService implements Ably
     property[name] = data;
     this.syncPropertiesObserver.publish(property);
 
-    if (this.isLocalParticipantHost) this.saveClientRoomState(name, data);
+    if (message.clientId === this.myParticipant.data.participantId) {
+      this.saveClientRoomState(name, data);
+    }
   }
 
   /**
@@ -1329,6 +1331,8 @@ export default class AblyRealtimeService extends RealtimeService implements Ably
   };
 
   public updatePresence3D = throttle((data: ParticipantInfo): void => {
+    console.trace('update');
+
     const participant = Object.assign({}, this.participantsOn3d[data.id]?.data ?? {}, data);
 
     this.participantsOn3d[data.id] = {
@@ -1338,6 +1342,8 @@ export default class AblyRealtimeService extends RealtimeService implements Ably
         ...this.participants[participant.id]?.data,
       },
     };
+
+    console.log('updatePresence3D', this.participantsOn3d[data.id]);
 
     if (!this.presence3DChannel) return;
 

--- a/src/web-components/comments/utils/watermark.ts
+++ b/src/web-components/comments/utils/watermark.ts
@@ -1,33 +1,33 @@
+let observer: MutationObserver;
+
 export function waterMarkElementObserver(shadowRoot: ShadowRoot) {
   const superVizCommentsId = shadowRoot.querySelector('#superviz-comments');
-  if (superVizCommentsId) {
+
+  if (superVizCommentsId && !observer) {
     const options = {
       childList: true,
       attributes: true,
       characterData: true,
       subtree: true,
     };
-    const superVizCommentsIdobserver = new MutationObserver((mutationsList, observer) => {
-      mutationsList.forEach((mutation) => {
-        const supervizCommentsDiv = shadowRoot.querySelector('#superviz-comments');
 
-        if (supervizCommentsDiv && supervizCommentsDiv.contains(mutation.target)) {
-          observer.disconnect();
-          reloadWaterMarkContent(shadowRoot);
-        }
+    observer = new MutationObserver((mutationsList) => {
+      mutationsList.forEach((mutation) => {
+        if (!mutation.removedNodes.length) return;
+
+        mutation.removedNodes.forEach((node: HTMLElement) => {
+          if (node.id === 'poweredby-footer') {
+            reloadWaterMarkContent(shadowRoot);
+          }
+        });
       });
     });
 
-    superVizCommentsIdobserver.observe(superVizCommentsId, options);
+    observer.observe(superVizCommentsId, options);
   }
 }
 
 export function reloadWaterMarkContent(shadowRoot: ShadowRoot) {
-  const poweredByFooterId = shadowRoot.querySelector('#poweredby-footer');
-  if (poweredByFooterId) {
-    poweredByFooterId.remove();
-  }
-
   const divPoweredByFooter = document.createElement('div');
   divPoweredByFooter.id = 'poweredby-footer';
   divPoweredByFooter.className = 'footer';


### PR DESCRIPTION

Previously, the host would update the event backup and it worked great, but when we changed the host logic to only work as video, this backup logic stopped working. To fix this, the attendee needs to update the event list with their events.