### PR TITLE
feat: react to keyboard mouse events

### DIFF
--- a/src/components/comments/canvas-pin-adapter/index.test.ts
+++ b/src/components/comments/canvas-pin-adapter/index.test.ts
@@ -147,7 +147,7 @@ describe('CanvasPinAdapter', () => {
 
     canvasPinAdapter.updateAnnotations([MOCK_ANNOTATION]);
 
-    expect(canvasPinAdapter['selectedPin']).not.toBeDefined();
+    expect(canvasPinAdapter['selectedPin']).toBeNull();
 
     canvasPinAdapter['annotationSelected'](
       new CustomEvent('select-annotation', {
@@ -168,7 +168,7 @@ describe('CanvasPinAdapter', () => {
 
     canvasPinAdapter.updateAnnotations([MOCK_ANNOTATION]);
 
-    expect(canvasPinAdapter['selectedPin']).not.toBeDefined();
+    expect(canvasPinAdapter['selectedPin']).toBeNull();
 
     canvasPinAdapter['annotationSelected'](
       new CustomEvent('select-annotation', {
@@ -189,7 +189,7 @@ describe('CanvasPinAdapter', () => {
 
     canvasPinAdapter.updateAnnotations([MOCK_ANNOTATION]);
 
-    expect(canvasPinAdapter['selectedPin']).not.toBeDefined();
+    expect(canvasPinAdapter['selectedPin']).toBeNull();
 
     canvasPinAdapter['annotationSelected'](
       new CustomEvent('select-annotation', {

--- a/src/components/comments/canvas-pin-adapter/index.test.ts
+++ b/src/components/comments/canvas-pin-adapter/index.test.ts
@@ -1,5 +1,3 @@
-import { positional } from 'yargs';
-
 import { MOCK_ANNOTATION } from '../../../../__mocks__/comments.mock';
 
 import { CanvasPin } from '.';

--- a/src/components/comments/canvas-pin-adapter/index.ts
+++ b/src/components/comments/canvas-pin-adapter/index.ts
@@ -148,7 +148,7 @@ export class CanvasPin implements PinAdapter {
     this.canvas.addEventListener('mousemove', this.onMouseMove);
     this.canvas.addEventListener('mouseout', this.onMouseLeave);
     this.canvas.addEventListener('mouseenter', this.onMouseEnter);
-    document.body.addEventListener('keyup', (e) => this.resetPins(e, this));
+    document.body.addEventListener('keyup', this.resetPins);
     document.body.addEventListener('select-annotation', this.annotationSelected);
   }
 
@@ -162,7 +162,7 @@ export class CanvasPin implements PinAdapter {
     this.canvas.removeEventListener('mousemove', this.onMouseMove);
     this.canvas.removeEventListener('mouseout', this.onMouseLeave);
     this.canvas.removeEventListener('mouseenter', this.onMouseEnter);
-    document.body.removeEventListener('keyup', (e) => this.resetPins(e, this));
+    document.body.removeEventListener('keyup', this.resetPins);
     document.body.removeEventListener('select-annotation', this.annotationSelected);
   }
 
@@ -184,10 +184,8 @@ export class CanvasPin implements PinAdapter {
   }
 
   /**
-   * @function resetPins
-   * @description Unselects selected pin and removes temporary pin.
-   * @param {that} this - The canvas pin adapter instance.
-   * @param {KeyboardEvent} event - The keyboard event object.
+   * @function resetSelectedPin
+   * @description Unselects a pin by removing its 'active' attribute
    * @returns {void}
    * */
   private resetSelectedPin(): void {
@@ -203,13 +201,12 @@ export class CanvasPin implements PinAdapter {
    * @param {KeyboardEvent} event - The keyboard event object.
    * @returns {void}
    * */
-  private resetPins(event?: KeyboardEvent, that: this = this): void {
+  private resetPins = (event?: KeyboardEvent): void => {
     if (event && event?.key !== 'Escape') return;
 
-    // use of "that" because using "this" normally wasn't working when pressing escape
-    that.resetSelectedPin();
-    that.removeAnnotationPin('temporary-pin');
-  }
+    this.resetSelectedPin();
+    this.removeAnnotationPin('temporary-pin');
+  };
 
   /**
    * @function createDivWrapper
@@ -295,11 +292,9 @@ export class CanvasPin implements PinAdapter {
     const { uuid } = detail;
     if (!uuid) return;
 
-    type PinElement = HTMLElement & { annotation: { uuid: string } };
+    const annotation = JSON.parse(this.selectedPin?.getAttribute('annotation') ?? '{}');
 
-    const annotation = this.selectedPin?.getAttribute('annotation') ?? '{}';
-
-    if (JSON.parse(annotation)?.uuid === uuid) {
+    if (annotation?.uuid === uuid) {
       this.resetPins();
       return;
     }

--- a/src/components/comments/canvas-pin-adapter/index.ts
+++ b/src/components/comments/canvas-pin-adapter/index.ts
@@ -273,7 +273,9 @@ export class CanvasPin implements PinAdapter {
 
     type PinElement = HTMLElement & { annotation: { uuid: string } };
 
-    if ((this.selectedPin as PinElement)?.annotation.uuid === uuid) {
+    const annotation = this.selectedPin?.getAttribute('annotation') ?? '{}';
+
+    if (JSON.parse(annotation)?.uuid === uuid) {
       this.resetPins();
       return;
     }

--- a/src/components/comments/index.ts
+++ b/src/components/comments/index.ts
@@ -220,6 +220,7 @@ export class Comments extends BaseComponent {
 
       if (element) {
         element.appendChild(this.button);
+        style = 'position: relative';
       } else {
         unfindableElement = true;
         buttonLocation = ButtonLocation.TOP_LEFT;

--- a/src/web-components/comments/components/annotation-item.ts
+++ b/src/web-components/comments/components/annotation-item.ts
@@ -190,6 +190,7 @@ export class CommentsAnnotationItem extends WebComponentsBaseElement {
             <superviz-comments-comment-input
               @create-comment=${this.createComment}
               eventType="create-comment"
+              @click=${(event: Event) => event.stopPropagation()}
             ></superviz-comments-comment-input>
           </div>
         </div>

--- a/src/web-components/comments/components/annotations.ts
+++ b/src/web-components/comments/components/annotations.ts
@@ -35,6 +35,12 @@ export class CommentsAnnotations extends WebComponentsBaseElement {
     this.annotation = null;
   };
 
+  private cancelTemporaryAnnotationEsc = (event: KeyboardEvent) => {
+    if (event?.key !== 'Escape') return;
+
+    this.annotation = null;
+  };
+
   connectedCallback(): void {
     super.connectedCallback();
     window.document.body.addEventListener(
@@ -45,6 +51,13 @@ export class CommentsAnnotations extends WebComponentsBaseElement {
       'close-temporary-annotation',
       this.cancelTemporaryAnnotation,
     );
+
+    const that = this;
+    window.document.body.addEventListener('keyup', (e) => {
+      if (e.key === 'Escape') {
+        that.cancelTemporaryAnnotationEsc(e);
+      }
+    });
   }
 
   disconnectedCallback(): void {
@@ -57,6 +70,13 @@ export class CommentsAnnotations extends WebComponentsBaseElement {
       'close-temporary-annotation',
       this.cancelTemporaryAnnotation,
     );
+
+    const that = this;
+    window.document.body.removeEventListener('keyup', (e) => {
+      if (e.key === 'Escape') {
+        that.cancelTemporaryAnnotationEsc(e);
+      }
+    });
   }
 
   protected render() {

--- a/src/web-components/comments/components/annotations.ts
+++ b/src/web-components/comments/components/annotations.ts
@@ -52,10 +52,9 @@ export class CommentsAnnotations extends WebComponentsBaseElement {
       this.cancelTemporaryAnnotation,
     );
 
-    const that = this;
     window.document.body.addEventListener('keyup', (e) => {
       if (e.key === 'Escape') {
-        that.cancelTemporaryAnnotationEsc(e);
+        this.cancelTemporaryAnnotationEsc(e);
       }
     });
   }
@@ -71,10 +70,9 @@ export class CommentsAnnotations extends WebComponentsBaseElement {
       this.cancelTemporaryAnnotation,
     );
 
-    const that = this;
     window.document.body.removeEventListener('keyup', (e) => {
       if (e.key === 'Escape') {
-        that.cancelTemporaryAnnotationEsc(e);
+        this.cancelTemporaryAnnotationEsc(e);
       }
     });
   }

--- a/src/web-components/comments/components/comment-input.ts
+++ b/src/web-components/comments/components/comment-input.ts
@@ -17,6 +17,7 @@ export class CommentsCommentInput extends WebComponentsBaseElement {
   declare commentsInput: HTMLTextAreaElement;
 
   private pinCoordinates: PinCoordinates | null = null;
+  private this = this;
 
   constructor() {
     super();
@@ -56,6 +57,7 @@ export class CommentsCommentInput extends WebComponentsBaseElement {
     if (this.eventType !== 'create-annotation') return;
 
     window.document.body.addEventListener('comment-input-focus', this.commentInputFocus);
+    window.document.body.addEventListener('keyup', this.sendEnter);
   }
 
   disconnectedCallback(): void {
@@ -94,6 +96,38 @@ export class CommentsCommentInput extends WebComponentsBaseElement {
     const btnSend = this.getSendBtn();
     btnSend.disabled = !(commentsInput.value.length > 0);
   }
+
+  private sendEnter = (e: KeyboardEvent) => {
+    if (e.key !== 'Enter') return;
+
+    if (e.shiftKey) return;
+
+    const input = this.getCommentInput();
+    const sendBtn = this.getSendBtn();
+    const text = input.value;
+
+    this.emitEvent(
+      this.eventType,
+      {
+        text,
+        position: {
+          x: this.pinCoordinates?.x ?? null,
+          y: this.pinCoordinates?.y ?? null,
+          z: this.pinCoordinates?.z ?? null,
+          type: this.pinCoordinates?.type ?? null,
+        },
+      },
+      {
+        composed: false,
+        bubbles: false,
+      },
+    );
+
+    this.pinCoordinates = null;
+    input.value = '';
+    sendBtn.disabled = true;
+    this.updateHeight();
+  };
 
   private send(e: Event) {
     e.preventDefault();

--- a/src/web-components/comments/components/comment-input.ts
+++ b/src/web-components/comments/components/comment-input.ts
@@ -17,7 +17,6 @@ export class CommentsCommentInput extends WebComponentsBaseElement {
   declare commentsInput: HTMLTextAreaElement;
 
   private pinCoordinates: PinCoordinates | null = null;
-  private this = this;
 
   constructor() {
     super();
@@ -57,7 +56,7 @@ export class CommentsCommentInput extends WebComponentsBaseElement {
     if (this.eventType !== 'create-annotation') return;
 
     window.document.body.addEventListener('comment-input-focus', this.commentInputFocus);
-    window.document.body.addEventListener('keyup', this.sendEnter);
+    this.addEventListener('keyup', this.sendEnter);
   }
 
   disconnectedCallback(): void {
@@ -103,8 +102,10 @@ export class CommentsCommentInput extends WebComponentsBaseElement {
     if (e.shiftKey) return;
 
     const input = this.getCommentInput();
+    const text = input.value.trim();
+
+    if (!text) return;
     const sendBtn = this.getSendBtn();
-    const text = input.value;
 
     this.emitEvent(
       this.eventType,

--- a/src/web-components/comments/components/comment-input.ts
+++ b/src/web-components/comments/components/comment-input.ts
@@ -52,8 +52,7 @@ export class CommentsCommentInput extends WebComponentsBaseElement {
 
   connectedCallback(): void {
     super.connectedCallback();
-
-    if (this.eventType !== 'create-annotation') return;
+    if (!['create-annotation', 'create-comment'].includes(this.eventType)) return;
 
     window.document.body.addEventListener('comment-input-focus', this.commentInputFocus);
     this.addEventListener('keyup', this.sendEnter);

--- a/src/web-components/comments/components/comment-item.ts
+++ b/src/web-components/comments/components/comment-item.ts
@@ -60,7 +60,9 @@ export class CommentsCommentItem extends WebComponentsBaseElement {
     });
   };
 
-  private resolveAnnotation = () => {
+  private resolveAnnotation = (event: Event) => {
+    event.stopPropagation();
+
     this.emitEvent(
       'resolve-annotation',
       {
@@ -130,6 +132,7 @@ export class CommentsCommentItem extends WebComponentsBaseElement {
         <superviz-comments-comment-input
           class="comment-item--editable"
           editable
+          @click=${(event: Event) => event.stopPropagation()}
           text=${this.text}
           eventType="update-comment"
           @update-comment=${this.updateComment}
@@ -185,6 +188,7 @@ export class CommentsCommentItem extends WebComponentsBaseElement {
               returnTo="label"
               position="bottom-right"
               @selected=${dropdownOptionsHandler}
+              @click=${(event: Event) => event.stopPropagation()}
             >
               <button slot="dropdown" class="icon-button icon-button--clickable icon-button--small">
                 <superviz-icon name="more" size="sm"></superviz-icon>

--- a/src/web-components/comments/components/content.ts
+++ b/src/web-components/comments/components/content.ts
@@ -30,7 +30,21 @@ export class CommentsContent extends WebComponentsBaseElement {
     annotationFilter: { type: String },
   };
 
+  private unselectAnnotation = () => {
+    this.selectedAnnotation = null;
+  };
+
+  private unselectAnnotationEsc = (event?: KeyboardEvent) => {
+    if (event && event?.key !== 'Escape') return;
+    this.selectedAnnotation = null;
+  };
+
   private selectAnnotation = ({ detail }: CustomEvent) => {
+    if (this.selectedAnnotation === detail.uuid) {
+      this.selectedAnnotation = null;
+      return;
+    }
+
     const { uuid } = detail;
     this.selectedAnnotation = uuid;
   };
@@ -66,12 +80,16 @@ export class CommentsContent extends WebComponentsBaseElement {
     super.connectedCallback();
 
     window.document.body.addEventListener('select-annotation', this.selectAnnotation);
+    window.document.body.addEventListener('keyup', this.unselectAnnotationEsc);
+    window.document.body.addEventListener('unselect-annotation', this.unselectAnnotation);
   }
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
 
     window.document.body.removeEventListener('select-annotation', this.selectAnnotation);
+    window.document.body.removeEventListener('keyup', this.unselectAnnotationEsc);
+    window.document.body.removeEventListener('unselect-annotation', this.unselectAnnotation);
   }
 
   protected render() {

--- a/src/web-components/comments/components/content.ts
+++ b/src/web-components/comments/components/content.ts
@@ -40,12 +40,13 @@ export class CommentsContent extends WebComponentsBaseElement {
   };
 
   private selectAnnotation = ({ detail }: CustomEvent) => {
-    if (this.selectedAnnotation === detail.uuid) {
+    const { uuid } = detail;
+
+    if (this.selectedAnnotation === uuid) {
       this.selectedAnnotation = null;
       return;
     }
 
-    const { uuid } = detail;
     this.selectedAnnotation = uuid;
   };
 


### PR DESCRIPTION
- When writing an annotation/comments, pressing "Enter" in the keyboard emits the event to create it
- Clicking twice on a pin/comment toggles its "selected"/"active" attribute
- Pressing "Esc" cancels a few things, such as the "selected"/"active" attribute of an annotation, or the creation of a new annotation