### PR TITLE
fix: update annotations when deleting comments

### DIFF
--- a/src/components/comments/index.ts
+++ b/src/components/comments/index.ts
@@ -321,6 +321,7 @@ export class Comments extends BaseComponent {
       const annotations = this.annotations.filter((annotation) => annotation.uuid !== uuid);
       this.updateAnnotationList(annotations);
       this.pinAdapter.removeAnnotationPin(uuid);
+      this.element.updateAnnotations(this.annotations);
     } catch (error) {
       this.logger.log('error when deleting annotation', error);
     }


### PR DESCRIPTION
Comments were being deleted from canvas, but not from the sidebar. Add call to updateAnnotationList inside deleteComment to achieve the desired behavior
