### PR TITLE
feat: add event to realtime start/stop

### DIFF
--- a/src/common/types/cdn.types.ts
+++ b/src/common/types/cdn.types.ts
@@ -1,4 +1,5 @@
 import { CanvasPin, Comments, MousePointers, Realtime, VideoComponent } from '../../components';
+import { RealtimeComponentEvent, RealtimeComponentState } from '../../components/realtime/types';
 import { LauncherFacade } from '../../core/launcher/types';
 import {
   CamerasPosition,
@@ -38,4 +39,6 @@ export interface SuperVizCdn {
   Realtime: typeof Realtime;
   Comments: typeof Comments;
   CanvasPin: typeof CanvasPin;
+  RealtimeComponentState: typeof RealtimeComponentState;
+  RealtimeComponentEvent: typeof RealtimeComponentEvent;
 }

--- a/src/components/realtime/index.test.ts
+++ b/src/components/realtime/index.test.ts
@@ -115,4 +115,24 @@ describe('realtime component', () => {
 
     expect(PUB_SUB_MOCK.subscribe).toHaveBeenCalledWith('test', callback);
   });
+
+  test('should not publish event when realtime is not started', () => {
+    console.error = jest.fn();
+    const RealtimeComponentInstance = new Realtime();
+
+    RealtimeComponentInstance.attach({
+      realtime: Object.assign({}, ABLY_REALTIME_MOCK, { isJoinedRoom: false }),
+      localParticipant: MOCK_LOCAL_PARTICIPANT,
+      group: MOCK_GROUP,
+      config: MOCK_CONFIG,
+      eventBus: EVENT_BUS_MOCK,
+    });
+
+    RealtimeComponentInstance.publish('test', 'test');
+
+    expect(console.error).toHaveBeenCalledWith(
+      "Realtime component is not started yet. You can't publish event test before start",
+    );
+    expect(PUB_SUB_MOCK.publish).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/realtime/index.test.ts
+++ b/src/components/realtime/index.test.ts
@@ -18,6 +18,8 @@ jest.mock('../../services/pubsub', () => ({
   PubSub: jest.fn().mockImplementation(() => PUB_SUB_MOCK),
 }));
 
+jest.useFakeTimers();
+
 describe('realtime component', () => {
   let RealtimeComponentInstance: Realtime;
 
@@ -66,5 +68,51 @@ describe('realtime component', () => {
     RealtimeComponentInstance.detach();
 
     expect(PUB_SUB_MOCK.destroy).toHaveBeenCalled();
+  });
+
+  test('when realtime is not joined room should store callback to subscribe', () => {
+    const callback = jest.fn();
+    const RealtimeComponentInstance = new Realtime();
+
+    RealtimeComponentInstance.attach({
+      realtime: Object.assign({}, ABLY_REALTIME_MOCK, { isJoinedRoom: false }),
+      localParticipant: MOCK_LOCAL_PARTICIPANT,
+      group: MOCK_GROUP,
+      config: MOCK_CONFIG,
+      eventBus: EVENT_BUS_MOCK,
+    });
+
+    RealtimeComponentInstance.subscribe('test', callback);
+
+    expect(PUB_SUB_MOCK.subscribe).not.toHaveBeenCalled();
+    expect(RealtimeComponentInstance['callbacksToSubscribeWhenJoined']).toEqual([
+      { event: 'test', callback },
+    ]);
+  });
+
+  test('should subscribe to events when joined room', async () => {
+    const callback = jest.fn();
+    const RealtimeComponentInstance = new Realtime();
+
+    RealtimeComponentInstance.attach({
+      realtime: Object.assign({}, ABLY_REALTIME_MOCK, { isJoinedRoom: false }),
+      localParticipant: MOCK_LOCAL_PARTICIPANT,
+      group: MOCK_GROUP,
+      config: MOCK_CONFIG,
+      eventBus: EVENT_BUS_MOCK,
+    });
+
+    RealtimeComponentInstance.subscribe('test', callback);
+
+    expect(PUB_SUB_MOCK.subscribe).not.toHaveBeenCalled();
+
+    RealtimeComponentInstance['realtime'] = Object.assign({}, ABLY_REALTIME_MOCK, {
+      isJoinedRoom: true,
+    });
+
+    // mock start call
+    RealtimeComponentInstance['start']();
+
+    expect(PUB_SUB_MOCK.subscribe).toHaveBeenCalledWith('test', callback);
   });
 });

--- a/src/components/realtime/index.ts
+++ b/src/components/realtime/index.ts
@@ -50,6 +50,13 @@ export class Realtime extends BaseComponent {
    * @returns {void}
    */
   public publish = (event: string, data?: unknown): void => {
+    if (!this.pubsub) {
+      const message = `Realtime component is not started yet. You can't publish event ${event} before start`;
+      this.logger.log(message);
+      console.error(message);
+      return;
+    }
+
     this.pubsub.publish(event, data);
   };
 

--- a/src/components/realtime/index.ts
+++ b/src/components/realtime/index.ts
@@ -4,11 +4,19 @@ import { RealtimeMessage } from '../../services/realtime/ably/types';
 import { BaseComponent } from '../base';
 import { ComponentNames } from '../types';
 
+import { RealtimeComponentEvent, RealtimeComponentState } from './types';
+
 export class Realtime extends BaseComponent {
   private pubsub: PubSub;
 
+  private callbacksToSubscribeWhenJoined: Array<{
+    event: string;
+    callback: (data: unknown) => void;
+  }> = [];
+
   protected logger: Logger;
   public name: ComponentNames;
+  private state: RealtimeComponentState = RealtimeComponentState.STOPPED;
 
   constructor() {
     super();
@@ -19,12 +27,19 @@ export class Realtime extends BaseComponent {
 
   protected destroy(): void {
     this.logger.log('destroyed');
+    this.changeState(RealtimeComponentState.STOPPED);
     this.pubsub.destroy();
   }
 
   protected start(): void {
     this.logger.log('started');
     this.pubsub = new PubSub(this.realtime);
+
+    this.callbacksToSubscribeWhenJoined.forEach(({ event, callback }) => {
+      this.pubsub.subscribe(event, callback);
+    });
+
+    this.changeState(RealtimeComponentState.STARTED);
   }
 
   /**
@@ -46,6 +61,11 @@ export class Realtime extends BaseComponent {
    * @returns {void}
    */
   public subscribe = (event: string, callback: (data: unknown) => void): void => {
+    if (!this.pubsub) {
+      this.callbacksToSubscribeWhenJoined.push({ event, callback });
+      return;
+    }
+
     this.pubsub.subscribe(event, callback);
   };
 
@@ -69,5 +89,18 @@ export class Realtime extends BaseComponent {
     eventName?: string,
   ): Promise<RealtimeMessage | Record<string, RealtimeMessage>> {
     return this.pubsub.fetchHistory(eventName);
+  }
+
+  /**
+   * @function changeState
+   * @description change realtime component state and publish state to client
+   * @param state
+   * @returns {void}
+   */
+  private changeState(state: RealtimeComponentState): void {
+    this.logger.log('realtime component @ changeState - state changed', state);
+    this.state = state;
+
+    this.pubsub.publishEventToClient(RealtimeComponentEvent.REALTIME_STATE_CHANGED, this.state);
   }
 }

--- a/src/components/realtime/types.ts
+++ b/src/components/realtime/types.ts
@@ -1,0 +1,8 @@
+export enum RealtimeComponentState {
+  STARTED = 'STARTED',
+  STOPPED = 'STOPPED',
+}
+
+export enum RealtimeComponentEvent {
+  REALTIME_STATE_CHANGED = 'realtime-component.state-changed',
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from './common/types/events.types';
 import { ParticipantType } from './common/types/participant.types';
 import { VideoComponent, MousePointers, Realtime, Comments, CanvasPin } from './components';
+import { RealtimeComponentEvent, RealtimeComponentState } from './components/realtime/types';
 import init from './core';
 import './web-components';
 import './common/styles/global.css';
@@ -51,6 +52,8 @@ if (window) {
     ParticipantType,
     LayoutPosition,
     CamerasPosition,
+    RealtimeComponentState,
+    RealtimeComponentEvent,
   };
 }
 
@@ -67,6 +70,8 @@ export {
   ParticipantType,
   LayoutPosition,
   CamerasPosition,
+  RealtimeComponentState,
+  RealtimeComponentEvent,
 };
 
 export default init;


### PR DESCRIPTION
Adds support to subscribe callbacks before initialization of the realtime, and publishes a message to the client whenever the state of the component changes. For now, we only have STARTED and STOPPED.