### PR TITLE
feat: make wio independent from presence

### DIFF
--- a/__mocks__/participants.mock.ts
+++ b/__mocks__/participants.mock.ts
@@ -19,6 +19,7 @@ export const MOCK_GROUP: Group = {
 };
 
 export const MOCK_ABLY_PARTICIPANT_DATA_1 = {
+  activeComponents: ['whoIsOnline'],
   name: 'unit-test-participant1-name',
   id: 'unit-test-participant1-id',
   avatar: MOCK_AVATAR,
@@ -28,6 +29,7 @@ export const MOCK_ABLY_PARTICIPANT_DATA_1 = {
 };
 
 export const MOCK_ABLY_PARTICIPANT_DATA_2 = {
+  activeComponents: ['whoIsOnline'],
   name: 'unit-test-participant2-name',
   id: 'unit-test-participant2-id',
   avatar: MOCK_AVATAR,

--- a/src/components/who-is-online/index.test.ts
+++ b/src/components/who-is-online/index.test.ts
@@ -1,28 +1,15 @@
 import { MOCK_CONFIG } from '../../../__mocks__/config.mock';
 import { EVENT_BUS_MOCK } from '../../../__mocks__/event-bus.mock';
 import {
-  MOCK_AVATAR,
+  MOCK_ABLY_PARTICIPANT,
+  MOCK_ABLY_PARTICIPANT_DATA_2,
   MOCK_GROUP,
   MOCK_LOCAL_PARTICIPANT,
 } from '../../../__mocks__/participants.mock';
 import { ABLY_REALTIME_MOCK } from '../../../__mocks__/realtime.mock';
 import { MeetingColorsHex } from '../../common/types/meeting-colors.types';
-import sleep from '../../common/utils/sleep';
-import { AblyRealtimeService } from '../../services/realtime';
-
-import { Participant } from './types';
 
 import { WhoIsOnline } from './index';
-
-// should equal the 'data' field of MOCK_ABLY_PARTICIPANT
-const MOCK_PARTICIPANT: Participant & { participantId: string } = {
-  id: 'unit-test-participant1-id',
-  avatar: MOCK_AVATAR,
-  color: MeetingColorsHex[0],
-  name: 'unit-test-participant1-name',
-  slotIndex: 0,
-  participantId: 'unit-test-participant1-ably-id',
-};
 
 describe('Who Is Online', () => {
   let whoIsOnlineComponent: WhoIsOnline;
@@ -51,35 +38,6 @@ describe('Who Is Online', () => {
 
   test('should create a new instance of Who Is Online', () => {
     expect(whoIsOnlineComponent).toBeInstanceOf(WhoIsOnline);
-  });
-
-  test('should update participants when participant joins', async () => {
-    const presenceData: Participant = {
-      id: 'participant2',
-      name: 'participant2',
-      color: undefined,
-      slotIndex: 3,
-    };
-
-    const currentParticipants = [...whoIsOnlineComponent['participants']];
-
-    whoIsOnlineComponent['onParticipantJoined'](presenceData);
-    expect(whoIsOnlineComponent['participants'].length).toBe(3);
-    expect(whoIsOnlineComponent['participants']).toEqual([...currentParticipants, presenceData]);
-  });
-
-  test('should remove participant from participants list on leave', () => {
-    const presenceData = {
-      ...MOCK_PARTICIPANT,
-    };
-
-    expect(whoIsOnlineComponent['participants'].length).toBe(2);
-    expect(whoIsOnlineComponent['participants'][0]).toEqual(MOCK_PARTICIPANT);
-
-    whoIsOnlineComponent['onParticipantLeave'](presenceData);
-
-    expect(whoIsOnlineComponent['participants'].length).toBe(1);
-    expect(whoIsOnlineComponent['participants'][0]).not.toEqual(MOCK_PARTICIPANT);
   });
 
   test('should position component inside div if id is provided', async () => {
@@ -113,129 +71,47 @@ describe('Who Is Online', () => {
     expect(whoIsOnlineComponent['element'].position).toBe('top: 20px; right: 40px;');
   });
 
-  test('should correctly update list when participant join even if participant already in the list', () => {
-    jest.useFakeTimers();
-    const presenceData = {
-      ...MOCK_PARTICIPANT,
-      color: undefined,
-    };
-
-    whoIsOnlineComponent['participants'][0] = presenceData;
-
-    expect(whoIsOnlineComponent['participants'].length).toBe(2);
-    whoIsOnlineComponent['onParticipantJoined'](presenceData);
-    jest.advanceTimersByTime(1000);
-    expect(whoIsOnlineComponent['participants'].length).toBe(2);
-    expect(whoIsOnlineComponent['participants'][0]).toEqual({
-      ...presenceData,
-      color: MeetingColorsHex[presenceData.slotIndex],
+  test('should correctly update participant list', () => {
+    whoIsOnlineComponent['onParticipantListUpdate']({
+      'unit-test-participant1-ably-id': MOCK_ABLY_PARTICIPANT,
     });
-    jest.useRealTimers();
+
+    expect(whoIsOnlineComponent['participants'].length).toBe(1);
+
+    whoIsOnlineComponent['onParticipantListUpdate']({
+      'unit-test-participant2-ably-id': {
+        ...MOCK_ABLY_PARTICIPANT,
+        data: MOCK_ABLY_PARTICIPANT_DATA_2,
+        id: 'unit-test-participant2-ably-id',
+      },
+      'unit-test-participant1-ably-id': MOCK_ABLY_PARTICIPANT,
+    });
+
+    expect(whoIsOnlineComponent['participants'].length).toBe(2);
   });
 
-  test("should correctly update user color if it isn't right initially", async () => {
-    const fakeId = 'fake-id';
-    whoIsOnlineComponent['getColorAfterDelay'](fakeId);
-    await sleep(200);
-    expect(whoIsOnlineComponent['participants'].map((participant) => participant.id)).not.toContain(
-      'fake-id',
-    );
-
-    whoIsOnlineComponent['onParticipantJoined']({ name: 'fake', id: 'fake-id', slotIndex: 3 });
-    whoIsOnlineComponent['realtime'] = Object.assign({}, ABLY_REALTIME_MOCK, {
-      getParticipants: {
-        ...whoIsOnlineComponent['realtime'].getParticipants,
-        'fake-id': {
-          data: {
-            name: 'fake',
-            slotIndex: 3,
-            id: 'fake-id',
-          },
-        },
+  test('should not update participant list if participant is does not have whoIsOnline activated', () => {
+    whoIsOnlineComponent['onParticipantListUpdate']({
+      'unit-test-participant1-ably-id': {
+        ...MOCK_ABLY_PARTICIPANT,
+        data: { ...MOCK_ABLY_PARTICIPANT, activeComponents: [] },
       },
     });
 
-    await sleep(500);
-
-    expect(whoIsOnlineComponent['participants'].map((participant) => participant.id)).toContain(
-      'fake-id',
-    );
+    expect(whoIsOnlineComponent['participants'].length).toBe(0);
   });
 
-  test('should update list of participants already in the room if initial list is incomplete', () => {
-    whoIsOnlineComponent['participants'] = [
-      { name: 'participant', id: 'random-participant', slotIndex: 3 },
-    ];
-    whoIsOnlineComponent['onParticipantListUpdate'](
-      whoIsOnlineComponent['realtime'].getParticipants,
-    );
-
-    expect(whoIsOnlineComponent['participants'].length).toBe(3); // 2 from real list + 1 from mock
-
-    const expected = [
-      { name: 'participant', id: 'random-participant', slotIndex: 3 },
-      ...Object.values(whoIsOnlineComponent['realtime'].getParticipants).map((participant) => {
-        const { color, avatar, id, name, participantId, slotIndex } = participant.data;
-        return { color, avatar, id, name, participantId, slotIndex };
-      }),
-    ];
-
-    expect(whoIsOnlineComponent['participants']).toStrictEqual(expected);
-  });
-
-  test('should interrupt update if participants list is equal to realtime participants list', () => {
-    whoIsOnlineComponent['compareParticipants'] = jest.fn(
-      whoIsOnlineComponent['compareParticipants'],
-    );
-
-    whoIsOnlineComponent['participants'] = Object.values(
-      whoIsOnlineComponent['realtime'].getParticipants,
-    ).map((participant) => {
-      const { slotIndex } = participant.data;
-      const color = MeetingColorsHex[slotIndex];
-
-      return {
-        ...participant.data,
-        participantId: participant.id,
-        color,
-        slotIndex,
-      };
+  test('should not add the same participant twice', () => {
+    whoIsOnlineComponent['onParticipantListUpdate']({
+      'unit-test-participant1-ably-id': MOCK_ABLY_PARTICIPANT,
     });
 
-    whoIsOnlineComponent['onParticipantListUpdate'](
-      whoIsOnlineComponent['realtime'].getParticipants,
-    );
+    expect(whoIsOnlineComponent['participants'].length).toBe(1);
 
-    expect(whoIsOnlineComponent['compareParticipants']).toBeCalled();
-    expect(whoIsOnlineComponent['compareParticipants']).toHaveReturnedWith(true);
-  });
-
-  test('should update users correctly if lists having same size is a coincidence', () => {
-    whoIsOnlineComponent['compareParticipants'] = jest.fn(
-      whoIsOnlineComponent['compareParticipants'],
-    );
-
-    whoIsOnlineComponent['participants'] = Object.values(
-      whoIsOnlineComponent['realtime'].getParticipants,
-    ).map((participant) => {
-      const { slotIndex } = participant.data;
-      const color = MeetingColorsHex[slotIndex + 4];
-
-      return {
-        ...participant.data,
-        id: participant.id + 'random',
-        participantId: participant.id + 'random',
-        color,
-        slotIndex,
-      };
+    whoIsOnlineComponent['onParticipantListUpdate']({
+      'unit-test-participant1-ably-id': MOCK_ABLY_PARTICIPANT,
     });
 
-    whoIsOnlineComponent['onParticipantListUpdate'](
-      whoIsOnlineComponent['realtime'].getParticipants,
-    );
-
-    expect(whoIsOnlineComponent['compareParticipants']).toBeCalled();
-    expect(whoIsOnlineComponent['compareParticipants']).toHaveReturnedWith(false);
-    expect(whoIsOnlineComponent['participants'].length).toBe(4);
+    expect(whoIsOnlineComponent['participants'].length).toBe(1);
   });
 });

--- a/src/components/who-is-online/index.ts
+++ b/src/components/who-is-online/index.ts
@@ -87,8 +87,6 @@ export class WhoIsOnline extends BaseComponent {
 
     if (isEqual(compare, participants)) return;
 
-    console.log(compare, participants);
-
     const currentParticipants: string[] = this.participants
       .filter((participant) => participant.color)
       .map((participant) => participant.id);

--- a/src/components/who-is-online/index.ts
+++ b/src/components/who-is-online/index.ts
@@ -1,11 +1,13 @@
+import { isEqual } from 'lodash';
+
 import { MeetingColorsHex } from '../../common/types/meeting-colors.types';
 import { Logger } from '../../common/utils';
+import { AblyParticipant } from '../../services/realtime/ably/types';
 import { WhoIsOnline as WhoIsOnlineElement } from '../../web-components';
 import { BaseComponent } from '../base';
 import { ComponentNames } from '../types';
 
 import { WhoIsOnlinePosition, Position, Participant } from './types';
-import { AblyParticipant } from '../../services/realtime/ably/types';
 
 export class WhoIsOnline extends BaseComponent {
   public name: ComponentNames;
@@ -30,20 +32,6 @@ export class WhoIsOnline extends BaseComponent {
   protected start(): void {
     this.subscribeToRealtimeEvents();
     this.positionWhoIsOnline();
-
-    this.participants = Object.values(this.realtime.getParticipants).map((participant) => {
-      const { slotIndex } = participant.data;
-      const color = MeetingColorsHex[slotIndex];
-
-      return {
-        ...participant.data,
-        participantId: participant.id,
-        color,
-        slotIndex,
-      };
-    });
-
-    this.element.participants = this.participants;
   }
 
   /**
@@ -64,8 +52,6 @@ export class WhoIsOnline extends BaseComponent {
    * @returns {void}
    */
   private subscribeToRealtimeEvents(): void {
-    this.realtime.presenceMouseParticipantJoinedObserver.subscribe(this.onParticipantJoined);
-    this.realtime.presenceMouseParticipantLeaveObserver.subscribe(this.onParticipantLeave);
     this.realtime.participantsObserver.subscribe(this.onParticipantListUpdate);
   }
 
@@ -75,118 +61,50 @@ export class WhoIsOnline extends BaseComponent {
    * @returns {void}
    */
   private unsubscribeToRealtimeEvents(): void {
-    this.realtime.presenceMouseParticipantJoinedObserver.unsubscribe(this.onParticipantJoined);
-    this.realtime.presenceMouseParticipantLeaveObserver.unsubscribe(this.onParticipantLeave);
     this.realtime.participantsObserver.unsubscribe(this.onParticipantListUpdate);
-  }
-
-  private compareParticipants() {
-    const realtimeParticipants = this.realtime.getParticipants;
-
-    return this.participants.every((participant) => {
-      return realtimeParticipants[participant.id];
-    });
   }
 
   /**
    * @function onParticipantListUpdate
-   * @description Receives data about participants in the room who were not loaded when the component was initialized
+   * @description Receives data about participants in the room who were not loaded
+   * when the component was initialized
    * @param {Record<string, AblyParticipant>} data
    * @returns {void}
    */
   private onParticipantListUpdate = (data: Record<string, AblyParticipant>) => {
-    const updatedParticipants = Object.values(data);
-    if (updatedParticipants.length === this.participants.length && this.compareParticipants())
-      return;
-
-    const currentParticipants: string[] = this.participants.map((participant) => participant.id);
-
-    const rawNewParticipants = updatedParticipants.filter(
-      ({ data: { id } }) => !currentParticipants.includes(id),
-    );
-
-    const newParticipants = rawNewParticipants.map((participant) => {
-      const { slotIndex } = participant.data;
-      const color = MeetingColorsHex[slotIndex ?? 16];
-      return { ...participant.data, color };
+    const updatedParticipants = Object.values(data).filter(({ data }) => {
+      return data.activeComponents.includes('whoIsOnline');
     });
 
-    this.participants = [...this.participants, ...newParticipants] as Participant[];
-
-    this.element.participants = this.participants;
-  };
-
-  /**
-   * @function onParticipantJoined
-   * @description Updates the participants list when a new participant joins the meeting
-   * @param {Ably.Types.PresenceMessage} participant
-   * @returns {void}
-   */
-  private onParticipantJoined = (data: Participant) => {
-    const participant = this.realtime.getParticipants[data.id]?.data;
-
-    const alreadyInList = participant
-      ? this.participants?.some((element) => element.id === participant.id)
-      : false;
-
-    const color = MeetingColorsHex[participant?.slotIndex];
-    data.slotIndex = participant?.slotIndex;
-
-    if (alreadyInList) {
-      this.participants = this.participants.map((participant) =>
-        participant.id === data.id ? { ...participant, ...data, color } : participant,
-      );
-    } else {
-      this.participants.push({ ...this.realtime.getParticipants[data.id]?.data, ...data, color });
-    }
-
-    if (!color) this.getColorAfterDelay(data.id);
-
-    this.element.participants = this.participants;
-  };
-
-  /**
-   * @function getColorAfterDelay
-   * @description Gets the color of the participant after realtime is done setting their slotIndex
-   * @param {string} id
-   * @returns {void}
-   */
-  private async getColorAfterDelay(id: string) {
-    const participant = this.realtime?.getParticipants[id]?.data;
-    const color = MeetingColorsHex[participant?.slotIndex];
-
-    const data = {
-      color,
-      slotIndex: participant?.slotIndex,
-    };
-
-    if (!color) {
-      setTimeout(() => {
-        this.getColorAfterDelay(id);
-      }, 100);
-      return;
-    }
-
-    this.participants = this.participants.map((participant) => {
-      return participant.id === id
-        ? {
-            ...participant,
-            ...data,
-          }
-        : participant;
+    const compare = updatedParticipants.map(({ data: { slotIndex, id } }) => {
+      const { color } = this.realtime.getSlotColor(slotIndex);
+      return { id, color };
     });
 
-    this.element.participants = this.participants;
-  }
+    const participants = this.participants.map(({ id, color }) => {
+      return { color, id };
+    });
 
-  /**
-   * @function onParticipantLeave
-   * @description Removes participant from the participants list when they leave the meeting
-   * @param {Ably.Types.PresenceMessage} participant
-   * @returns {void}
-   */
-  private onParticipantLeave = ({ id }): void => {
-    this.participants = this.participants.filter((participant) => participant.id !== id);
+    if (isEqual(compare, participants)) return;
+
+    const currentParticipants: string[] = this.participants
+      .filter((participant) => participant.color)
+      .map((participant) => participant.id);
+
+    const newParticipants = updatedParticipants
+      .filter(({ id }) => {
+        return !currentParticipants.includes(id);
+      })
+      .map(({ data: { name, id, slotIndex } }) => {
+        const { color } = this.realtime.getSlotColor(slotIndex);
+        return { name, id, slotIndex, color };
+      });
+
+    this.participants = [
+      ...this.participants.filter(({ id }) => !currentParticipants.includes(id)),
+      ...newParticipants,
+    ];
+
     this.element.participants = this.participants;
   };
 

--- a/src/components/who-is-online/index.ts
+++ b/src/components/who-is-online/index.ts
@@ -73,7 +73,7 @@ export class WhoIsOnline extends BaseComponent {
    */
   private onParticipantListUpdate = (data: Record<string, AblyParticipant>) => {
     const updatedParticipants = Object.values(data).filter(({ data }) => {
-      return data.activeComponents.includes('whoIsOnline');
+      return data.activeComponents?.includes('whoIsOnline');
     });
 
     const compare = updatedParticipants.map(({ data: { slotIndex, id } }) => {
@@ -86,6 +86,8 @@ export class WhoIsOnline extends BaseComponent {
     });
 
     if (isEqual(compare, participants)) return;
+
+    console.log(compare, participants);
 
     const currentParticipants: string[] = this.participants
       .filter((participant) => participant.color)


### PR DESCRIPTION
With these changes, the only prerequisite to use Who Is Online will be activating the component itself, instead of depending on the participant also activating Presence. Thanks to that change, a good chunk of code was removed due to contrived or out of date logic, and a few changes were made to the already existing method of updating the participants list.