### PR TITLE
fix: display extra participants avatars with correct proportions

### DIFF
--- a/src/web-components/who-is-online/components/dropdown.ts
+++ b/src/web-components/who-is-online/components/dropdown.ts
@@ -119,14 +119,14 @@ export class WhoIsOnlineDropdown extends WebComponentsBaseElement {
         @selected=${this.dropdownOptionsHandler}
         icons="${JSON.stringify(icons)}"
         > -->
-        <div class=${classMap(contentClasses)} @click=${this.selectParticipant(
-        participant.id,
-      )} slot="dropdown">
+        <div 
+          class=${classMap(contentClasses)} 
+          @click=${this.selectParticipant(participant.id)} slot="dropdown">
           <div class="who-is-online-dropdown__participant" style="border-color: 
           ${participant.color}">
-              <div class="who-is-online-dropdown__avatar" style="background-color: ${
-                participant.color
-              }; color: ${letterColor}">
+              <div 
+                class="who-is-online-dropdown__avatar" 
+                style="background-color: ${participant.color}; color: ${letterColor}">
                 ${participant.name?.at(0)}
               </div>
             </div>

--- a/src/web-components/who-is-online/css/dropdown.style.ts
+++ b/src/web-components/who-is-online/css/dropdown.style.ts
@@ -30,7 +30,7 @@ export const dropdownStyle = css`
     height: 40px;
     border: 2px solid #878291;
     border-radius: 50%;
-    flex: 1 0 40px;
+    flex-basis: 40px;
   }
 
   .who-is-online-dropdown__avatar {
@@ -117,12 +117,16 @@ export const dropdownStyle = css`
     .who-is-online-dropdown__participant {
       width: 32px;
       height: 32px;
-      flex: 1 0 32px;
+      flex-basis: 32px;
     }
 
     .who-is-online-dropdown__avatar {
       width: 24px;
       height: 24px;
+    }
+
+    .dropdown-list > div {
+      min-width: 192px;
     }
   }
 `;

--- a/src/web-components/who-is-online/css/dropdown.style.ts
+++ b/src/web-components/who-is-online/css/dropdown.style.ts
@@ -30,7 +30,8 @@ export const dropdownStyle = css`
     height: 40px;
     border: 2px solid #878291;
     border-radius: 50%;
-    flex-basis: 40px;
+    max-width: 40px;
+    flex: 1 0 40px;
   }
 
   .who-is-online-dropdown__avatar {
@@ -117,7 +118,11 @@ export const dropdownStyle = css`
     .who-is-online-dropdown__participant {
       width: 32px;
       height: 32px;
-      flex-basis: 32px;
+    }
+
+    .who-is-online-dropdown__participant {
+      flex: 1 0 32px;
+      max-width: 32px;
     }
 
     .who-is-online-dropdown__avatar {


### PR DESCRIPTION
Before:
![image](https://github.com/SuperViz/sdk/assets/111044527/751e98e4-1ae1-43f4-9fec-7c963408565e)

After:
![image](https://github.com/SuperViz/sdk/assets/111044527/bc02e00b-bc35-4d9e-bffc-d07c8a6182ac)
