### PR TITLE
ci: update secret name for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SUPERVIZ_DEV_USER_TOKEN }}
           repository: superviz/samples
           event-type: new-release
           client-payload: '{"version": "v0.0.0"}'


### PR DESCRIPTION
For this PR to be merged it will need the PAT (Personal Access Token) for SuperViz-Dev with access to GitHub Actions as a Secret named token: `GITHUB_SUPERVIZ_DEV_USER_TOKEN `