### PR TITLE
fix: wio interaction with presence

### DIFF
--- a/src/components/comments/html-pin-adapter/index.test.ts
+++ b/src/components/comments/html-pin-adapter/index.test.ts
@@ -1047,7 +1047,7 @@ describe('HTMLPinAdapter', () => {
     test('should clear element then do nothing if new value is filtered', () => {
       document.body.innerHTML =
         '<div id="container"><div data-superviz-id="1-matches";"><div><div data-superviz-id="does-not-match"></div></div>';
-      instance = new HTMLPin('container', { dataAttributeNameFilters: [/.*-matches$/] });
+      instance = new HTMLPin('container', { dataAttributeValueFilters: [/.*-matches$/] });
       const change = {
         target: document.body.querySelector('[data-superviz-id="1-matches"]') as HTMLElement,
         oldValue: '2',
@@ -1069,7 +1069,7 @@ describe('HTMLPinAdapter', () => {
     test('should not clear element if old value was skipped', () => {
       document.body.innerHTML =
         '<div id="container"><div data-superviz-id="1-matches";"><div><div data-superviz-id="does-not-match"></div></div>';
-      instance = new HTMLPin('container', { dataAttributeNameFilters: [/.*-matches$/] });
+      instance = new HTMLPin('container', { dataAttributeValueFilters: [/.*-matches$/] });
       const change = {
         target: document.body.querySelector('[data-superviz-id="does-not-match"]') as HTMLElement,
         oldValue: '1-matches',
@@ -1229,7 +1229,7 @@ describe('HTMLPinAdapter', () => {
         '<div id="container"><div data-superviz-id="1-matches";"><div><div data-superviz-id="does-not-match"></div></div>';
       const container = document.getElementById('container') as HTMLElement;
 
-      instance = new HTMLPin('container', { dataAttributeNameFilters: [/.*-matches$/] });
+      instance = new HTMLPin('container', { dataAttributeValueFilters: [/.*-matches$/] });
       const spy = jest.spyOn(instance as any, 'setElementReadyToPin');
 
       instance['container'] = container;

--- a/src/components/comments/html-pin-adapter/index.test.ts
+++ b/src/components/comments/html-pin-adapter/index.test.ts
@@ -289,9 +289,6 @@ describe('HTMLPinAdapter', () => {
 
       instance['renderAnnotationsPins']();
 
-      // // delete this avoids an error being throw when the pin is destroyed
-      // delete instance['elementsWithDataId']['1'];
-
       expect(instance['pins'].size).toEqual(0);
     });
 

--- a/src/components/comments/html-pin-adapter/index.test.ts
+++ b/src/components/comments/html-pin-adapter/index.test.ts
@@ -284,10 +284,7 @@ describe('HTMLPinAdapter', () => {
         },
       ];
 
-      instance['divWrappers']
-        .get('1')
-        ?.querySelector('[data-pins-wrapper]')!
-        .removeAttribute('data-pins-wrapper');
+      instance['divWrappers'].delete('1');
       instance['pins'].clear();
 
       instance['renderAnnotationsPins']();
@@ -708,7 +705,7 @@ describe('HTMLPinAdapter', () => {
       jest.restoreAllMocks();
     });
 
-    test('should remove previous temporary pin container when rendering temporary pin over another element', () => {
+    test('should remove previous temporary pin when rendering temporary pin over another element', () => {
       instance['onClick']({
         clientX: 100,
         clientY: 100,
@@ -721,7 +718,6 @@ describe('HTMLPinAdapter', () => {
         currentTarget.getAttribute('data-wrapper-id'),
       );
 
-      const removeSpy = jest.spyOn(instance['temporaryPinContainer'] as any, 'remove');
       const deleteSpy = jest.spyOn(instance['pins'], 'delete');
 
       instance['onClick']({
@@ -731,7 +727,6 @@ describe('HTMLPinAdapter', () => {
         currentTarget: document.body.querySelector('[data-wrapper-id="2"]') as HTMLElement,
       } as unknown as MouseEvent);
 
-      expect(removeSpy).toHaveBeenCalled();
       expect(deleteSpy).toHaveBeenCalled();
       expect(instance['pins'].has('temporary-pin')).toBeTruthy();
       expect(instance['temporaryPinCoordinates'].elementId).toBe('2');
@@ -807,54 +802,33 @@ describe('HTMLPinAdapter', () => {
 
     test('should add temporary pin to element', () => {
       const element = document.body.querySelector('[data-superviz-id="1"]') as HTMLElement;
-      const temporaryPinContainer = document.createElement('div');
-      temporaryPinContainer.id = 'temp-container';
       const pin = document.createElement('div');
       pin.id = 'temp-pin';
-      const spy = jest
-        .spyOn(instance as any, 'createTemporaryPinContainer')
-        .mockReturnValue(temporaryPinContainer);
 
       instance['addTemporaryPinToElement']('1', pin);
 
-      expect(spy).toHaveBeenCalled();
-      expect(temporaryPinContainer.querySelector('#temp-pin')).toBe(pin);
-      expect(instance['divWrappers'].get('1')?.querySelector('#temp-container')).toBe(
-        temporaryPinContainer,
-      );
+      const wrapper = instance['divWrappers'].get('1') as HTMLElement;
+      expect(element.firstElementChild).toBe(wrapper);
+      expect(wrapper.firstElementChild).toBe(pin);
     });
 
     test('should not add temporary pin to element if element is not found', () => {
-      const element = document.body.querySelector('[data-superviz-id="1"]') as HTMLElement;
-      const temporaryPinContainer = document.createElement('div');
-      temporaryPinContainer.id = 'temp-container';
       const pin = document.createElement('div');
       pin.id = 'temp-pin';
-      const spy = jest
-        .spyOn(instance as any, 'createTemporaryPinContainer')
-        .mockReturnValue(temporaryPinContainer);
 
       instance['addTemporaryPinToElement']('not-found', pin);
 
-      expect(spy).not.toHaveBeenCalled();
-      expect(temporaryPinContainer.querySelector('#temp-pin')).toBe(null);
-      expect(instance['divWrappers'].get('1')?.querySelector('#temp-container')).toBe(null);
+      expect(instance['divWrappers'].get('1')?.querySelector('#temp-pin')).toBe(null);
     });
 
     test('should not add temporary pin to element if wrapper is not found', () => {
-      const element = document.body.querySelector('[data-superviz-id="1"]') as HTMLElement;
-      const temporaryPinContainer = document.createElement('div');
-      temporaryPinContainer.id = 'temp-container';
       const pin = document.createElement('div');
       pin.id = 'temp-pin';
-      const spy = jest
-        .spyOn(instance as any, 'createTemporaryPinContainer')
-        .mockReturnValue(temporaryPinContainer);
+
       instance['divWrappers'].delete('1');
       instance['addTemporaryPinToElement']('1', pin);
 
-      expect(spy).not.toHaveBeenCalled();
-      expect(temporaryPinContainer.querySelector('#temp-pin')).toBe(null);
+      expect(document.getElementById('temp-pin')).toBe(null);
     });
   });
 
@@ -864,9 +838,6 @@ describe('HTMLPinAdapter', () => {
 
       instance['divWrappers'].clear();
       const wrapper = instance['createWrapper'](element, '1');
-
-      const pinsWrapper = wrapper.querySelector('[data-pins-wrapper]') as HTMLElement;
-      const containerRect = element.getBoundingClientRect();
 
       expect(wrapper).toBeInstanceOf(HTMLDivElement);
       expect(wrapper.style.position).toEqual('absolute');
@@ -878,14 +849,6 @@ describe('HTMLPinAdapter', () => {
       expect(wrapper.style.cursor).toEqual('default');
       expect(wrapper.getAttribute('data-wrapper-id')).toEqual('1');
       expect(wrapper.id).toEqual('superviz-id-1');
-
-      expect(pinsWrapper).toBeInstanceOf(HTMLDivElement);
-      expect(pinsWrapper.style.position).toEqual('absolute');
-      expect(pinsWrapper.style.overflow).toEqual('hidden');
-      expect(pinsWrapper.style.top).toEqual('0px');
-      expect(pinsWrapper.style.left).toEqual('0px');
-      expect(pinsWrapper.style.width).toEqual('100%');
-      expect(pinsWrapper.style.height).toEqual('100%');
     });
 
     test('should not create a new wrapper if wrapper already exists', () => {

--- a/src/components/comments/html-pin-adapter/index.ts
+++ b/src/components/comments/html-pin-adapter/index.ts
@@ -133,9 +133,10 @@ export class HTMLPin implements PinAdapter {
     this.voidElementsWrappers.clear();
     this.voidElementsWrappers = undefined;
     this.annotations = [];
-    cancelAnimationFrame(this.animateFrame);
     document.body.removeEventListener('select-annotation', this.annotationSelected);
     document.body.removeEventListener('toggle-annotation-sidebar', this.onToggleAnnotationSidebar);
+
+    cancelAnimationFrame(this.animateFrame);
   }
 
   /**
@@ -187,8 +188,10 @@ export class HTMLPin implements PinAdapter {
    * @returns {void}
    */
   private animate = (): void => {
-    this.updatePinsPositions();
-    requestAnimationFrame(this.animate);
+    if (this.voidElementsWrappers) {
+      this.updatePinsPositions();
+      this.animateFrame = requestAnimationFrame(this.animate);
+    }
   };
 
   /**

--- a/src/components/comments/html-pin-adapter/index.ts
+++ b/src/components/comments/html-pin-adapter/index.ts
@@ -34,7 +34,7 @@ export class HTMLPin implements PinAdapter {
   private selectedPin: HTMLElement | null = null;
   private dataAttribute: string = 'data-superviz-id';
   private animateFrame: number;
-  private dataAttributeNameFilters: RegExp[];
+  private dataAttributeValueFilters: RegExp[];
 
   // Coordinates/Positions
   private mouseDownCoordinates: Simple2DPoint;
@@ -82,7 +82,7 @@ export class HTMLPin implements PinAdapter {
     if (typeof options !== 'object')
       throw new Error('Second argument of the HTMLPin constructor must be an object');
 
-    const { dataAttributeName, dataAttributeNameFilters } = options;
+    const { dataAttributeName, dataAttributeValueFilters } = options;
 
     if (dataAttributeName === '') throw new Error('dataAttributeName must be a non-empty string');
     if (dataAttributeName === null) throw new Error('dataAttributeName cannot be null');
@@ -90,7 +90,7 @@ export class HTMLPin implements PinAdapter {
       throw new Error('dataAttributeName must be a non-empty string');
 
     this.dataAttribute = dataAttributeName || this.dataAttribute;
-    this.dataAttributeNameFilters = dataAttributeNameFilters || [];
+    this.dataAttributeValueFilters = dataAttributeValueFilters || [];
 
     this.isActive = false;
     this.prepareElements();
@@ -225,7 +225,7 @@ export class HTMLPin implements PinAdapter {
 
     elementsWithDataId.forEach((el: HTMLElement) => {
       const id = el.getAttribute(this.dataAttribute);
-      const skip = this.dataAttributeNameFilters.some((filter, index) => {
+      const skip = this.dataAttributeValueFilters.some((filter, index) => {
         return id.match(filter);
       });
 
@@ -800,7 +800,7 @@ export class HTMLPin implements PinAdapter {
       const dataId = (target as HTMLElement).getAttribute(this.dataAttribute);
       if ((!dataId && !oldValue) || dataId === oldValue) return;
 
-      const oldValueSkipped = this.dataAttributeNameFilters.some((filter) =>
+      const oldValueSkipped = this.dataAttributeValueFilters.some((filter) =>
         oldValue.match(filter),
       );
 
@@ -818,7 +818,7 @@ export class HTMLPin implements PinAdapter {
         return;
       }
 
-      const skip = this.dataAttributeNameFilters.some((filter) => dataId.match(filter));
+      const skip = this.dataAttributeValueFilters.some((filter) => dataId.match(filter));
 
       if ((oldValue && this.elementsWithDataId[oldValue]) || skip) {
         this.clearElement(oldValue);

--- a/src/components/comments/html-pin-adapter/index.ts
+++ b/src/components/comments/html-pin-adapter/index.ts
@@ -243,7 +243,7 @@ export class HTMLPin implements PinAdapter {
   private setAddCursor(): void {
     Object.keys(this.elementsWithDataId).forEach((id) => {
       this.divWrappers.get(id).style.cursor =
-        'url("https://production.cdn.superviz.com/static/pin-add.png") 0 100, pointer';
+        'url("https://production.cdn.superviz.com/static/pin-html.png") 0 100, pointer';
       this.divWrappers.get(id).style.pointerEvents = 'auto';
     });
   }
@@ -526,7 +526,7 @@ export class HTMLPin implements PinAdapter {
     if (!this.isActive || !this.isPinsVisible) return;
 
     this.divWrappers.get(id).style.cursor =
-      'url("https://production.cdn.superviz.com/static/pin-add.png") 0 100, pointer';
+      'url("https://production.cdn.superviz.com/static/pin-html.png") 0 100, pointer';
     this.divWrappers.get(id).style.pointerEvents = 'auto';
     this.addElementListeners(id);
   }

--- a/src/components/comments/html-pin-adapter/index.ts
+++ b/src/components/comments/html-pin-adapter/index.ts
@@ -360,8 +360,9 @@ export class HTMLPin implements PinAdapter {
     let temporaryPin = this.pins.get('temporary-pin');
 
     if (elementId && elementId !== this.temporaryPinCoordinates.elementId) {
-      this.temporaryPinContainer.remove();
+      this.pins.get('temporary-pin').remove();
       this.pins.delete('temporary-pin');
+
       this.temporaryPinCoordinates.elementId = elementId;
       temporaryPin = null;
     }
@@ -411,17 +412,15 @@ export class HTMLPin implements PinAdapter {
       const { x, y, elementId, type } = JSON.parse(annotation.position) as PinCoordinates;
       if (type !== 'html') return;
 
-      const element = this.elementsWithDataId[elementId];
-      if (!element) return;
-
-      const wrapper = this.divWrappers
-        .get(elementId)
-        ?.querySelector('[data-pins-wrapper]') as HTMLDivElement;
-      if (!wrapper) return;
-
       if (this.pins.has(annotation.uuid)) {
         return;
       }
+
+      const element = this.elementsWithDataId[elementId];
+      if (!element) return;
+
+      const wrapper = this.divWrappers.get(elementId);
+      if (!wrapper) return;
 
       const pinElement = this.createPin(annotation, x, y);
       wrapper.appendChild(pinElement);
@@ -460,8 +459,7 @@ export class HTMLPin implements PinAdapter {
 
     const wrapper = this.divWrappers.get(id);
     if (wrapper) {
-      const pinsWrapper = wrapper.querySelector('[data-pins-wrapper]') as HTMLDivElement;
-      const pins = pinsWrapper.children;
+      const pins = wrapper.children;
       const { length } = pins;
 
       for (let i = 0; i < length; ++i) {
@@ -545,7 +543,6 @@ export class HTMLPin implements PinAdapter {
     if (!this.temporaryPinCoordinates.elementId) return;
 
     this.removeAnnotationPin('temporary-pin');
-    this.temporaryPinContainer?.remove();
     this.temporaryPinCoordinates = {};
   };
 
@@ -597,29 +594,10 @@ export class HTMLPin implements PinAdapter {
     const wrapper = this.divWrappers.get(elementId);
     if (!wrapper) return;
 
-    const temporaryContainer = this.createTemporaryPinContainer();
-    temporaryContainer.appendChild(pin);
-
-    wrapper.appendChild(temporaryContainer);
+    wrapper.appendChild(pin);
   }
 
   // ------- helper functions -------
-  /**
-   * @function createTemporaryPinContainer
-   * @description return a temporary pin container
-   * @returns {HTMLDivElement} the temporary pin container, separated from the main pins container to avoid overflow issues
-   */
-  private createTemporaryPinContainer(): HTMLDivElement {
-    const temporaryContainer = document.createElement('div');
-    temporaryContainer.style.position = 'absolute';
-    temporaryContainer.style.top = '0';
-    temporaryContainer.style.left = '0';
-    temporaryContainer.style.width = '100%';
-    temporaryContainer.style.height = '100%';
-    temporaryContainer.id = 'temporary-pin-container';
-    return temporaryContainer;
-  }
-
   /**
    * @function createPin
    * @description creates a pin element and sets its properties
@@ -666,16 +644,6 @@ export class HTMLPin implements PinAdapter {
     containerWrapper.style.width = `100%`;
     containerWrapper.style.height = `100%`;
 
-    const pinsWrapper = document.createElement('div');
-    pinsWrapper.setAttribute('data-pins-wrapper', '');
-    pinsWrapper.style.position = 'absolute';
-    pinsWrapper.style.overflow = 'hidden';
-    pinsWrapper.style.top = '0';
-    pinsWrapper.style.left = '0';
-    pinsWrapper.style.width = '100%';
-    pinsWrapper.style.height = '100%';
-    containerWrapper.appendChild(pinsWrapper);
-
     if (!this.VOID_ELEMENTS.includes(this.elementsWithDataId[id].tagName.toLowerCase())) {
       this.elementsWithDataId[id].appendChild(containerWrapper);
       this.setPositionNotStatic(this.elementsWithDataId[id]);
@@ -715,15 +683,6 @@ export class HTMLPin implements PinAdapter {
     if (position !== 'static') return;
 
     element.style.setProperty('position', 'relative');
-  }
-
-  /**
-   * @function temporaryPinContainer
-   * @description returns the temporary pin container
-   * @returns {HTMLDivElement} the temporary pin container
-   */
-  private get temporaryPinContainer(): HTMLDivElement {
-    return document.getElementById('temporary-pin-container') as HTMLDivElement;
   }
 
   // ------- callbacks -------

--- a/src/components/comments/html-pin-adapter/types.ts
+++ b/src/components/comments/html-pin-adapter/types.ts
@@ -16,5 +16,5 @@ export type HorizontalSide = 'left' | 'right';
 
 export interface HTMLPinOptions {
   dataAttributeName?: string;
-  dataAttributeNameFilters?: RegExp[];
+  dataAttributeValueFilters?: RegExp[];
 }

--- a/src/components/who-is-online/index.ts
+++ b/src/components/who-is-online/index.ts
@@ -133,7 +133,7 @@ export class WhoIsOnline extends BaseComponent {
         const { color } = this.realtime.getSlotColor(slotIndex);
         const isLocal = this.localParticipant.id === id;
         const joinedPresence = activeComponents.some((component) => component.includes('presence'));
-        this.setLocalData(isLocal, !joinedPresence, color);
+        this.setLocalData(isLocal, !joinedPresence, color, joinedPresence);
 
         return { name, id, slotIndex, color, isLocal, joinedPresence, avatar };
       });
@@ -149,11 +149,16 @@ export class WhoIsOnline extends BaseComponent {
     this.element.updateParticipants(this.participants);
   };
 
-  private setLocalData = (local: boolean, disable: boolean, color: string) => {
+  private setLocalData = (
+    local: boolean,
+    disable: boolean,
+    color: string,
+    joinedPresence: boolean,
+  ) => {
     if (!local) return;
 
     this.element.disableDropdown = disable;
-    this.element.localParticipantData = { color, id: this.localParticipant.id };
+    this.element.localParticipantData = { color, id: this.localParticipant.id, joinedPresence };
   };
 
   /**

--- a/src/web-components/who-is-online/components/dropdown.ts
+++ b/src/web-components/who-is-online/components/dropdown.ts
@@ -7,7 +7,14 @@ import { Participant } from '../../../components/who-is-online/types';
 import { WebComponentsBase } from '../../base';
 import { dropdownStyle } from '../css';
 
-import { Following, WIODropdownOptions, PositionOptions } from './types';
+import {
+  Following,
+  WIODropdownOptions,
+  PositionOptions,
+  TooltipData,
+  VerticalSide,
+  HorizontalSide,
+} from './types';
 
 const WebComponentsBaseElement = WebComponentsBase(LitElement);
 const styles: CSSResultGroup[] = [WebComponentsBaseElement.styles, dropdownStyle];
@@ -17,12 +24,12 @@ export class WhoIsOnlineDropdown extends WebComponentsBaseElement {
   static styles = styles;
 
   declare open: boolean;
-  declare align: 'left' | 'right';
-  declare position: 'top' | 'bottom';
+  declare align: HorizontalSide;
+  declare position: VerticalSide;
   declare participants: Participant[];
   private textColorValues: number[];
   declare selected: string;
-  private originalPosition: 'top' | 'bottom';
+  private originalPosition: VerticalSide;
   private menu: HTMLElement;
   private dropdownContent: HTMLElement;
   private host: HTMLElement;
@@ -163,9 +170,9 @@ export class WhoIsOnlineDropdown extends WebComponentsBaseElement {
           }))
           .slice(0, 2);
 
-        const tooltipData = {
+        const tooltipData: TooltipData = {
           name,
-        } as { name: string; action: string };
+        };
 
         if (this.localParticipantJoinedPresence && joinedPresence) {
           tooltipData.action = 'Click to Follow';
@@ -320,13 +327,13 @@ export class WhoIsOnlineDropdown extends WebComponentsBaseElement {
 
     if (action === PositionOptions['USE-ORIGINAL']) {
       const originalVertical = this.originalPosition.split('-')[0];
-      this.position = this.position.replace(/top|bottom/, originalVertical) as 'top' | 'bottom';
+      this.position = this.position.replace(/top|bottom/, originalVertical) as VerticalSide;
       return;
     }
 
     const newSide = innerHeight - bottom > top ? 'bottom' : 'top';
     const previousSide = this.position.split('-')[0];
-    const newPosition = this.position.replace(previousSide, newSide) as 'top' | 'bottom';
+    const newPosition = this.position.replace(previousSide, newSide) as VerticalSide;
 
     this.position = newPosition;
   };

--- a/src/web-components/who-is-online/components/dropdown.ts
+++ b/src/web-components/who-is-online/components/dropdown.ts
@@ -30,6 +30,7 @@ export class WhoIsOnlineDropdown extends WebComponentsBaseElement {
   declare showSeeMoreTooltip: boolean;
   declare showParticipantTooltip: boolean;
   declare following: Following;
+  declare localParticipantJoinedPresence: boolean;
 
   static properties = {
     open: { type: Boolean },
@@ -41,6 +42,7 @@ export class WhoIsOnlineDropdown extends WebComponentsBaseElement {
     following: { type: Object },
     showSeeMoreTooltip: { type: Boolean },
     showParticipantTooltip: { type: Boolean },
+    localParticipantJoinedPresence: { type: Boolean },
   };
 
   constructor() {
@@ -161,6 +163,14 @@ export class WhoIsOnlineDropdown extends WebComponentsBaseElement {
           }))
           .slice(0, 2);
 
+        const tooltipData = {
+          name,
+        } as { name: string; action: string };
+
+        if (this.localParticipantJoinedPresence && joinedPresence) {
+          tooltipData.action = 'Click to Follow';
+        }
+
         return html`
         <superviz-dropdown
         options=${JSON.stringify(options)}
@@ -169,7 +179,7 @@ export class WhoIsOnlineDropdown extends WebComponentsBaseElement {
         @selected=${this.close}
         icons="${JSON.stringify(icons)}"
         ?disabled=${disableDropdown}
-        onHoverData=${JSON.stringify({ name, action: 'Click to follow' })}
+        onHoverData=${JSON.stringify(tooltipData)}
         ?canShowTooltip=${this.showParticipantTooltip}
         ?shiftTooltipLeft=${true}
         @toggle-dropdown-state=${this.toggleShowTooltip}

--- a/src/web-components/who-is-online/components/types.ts
+++ b/src/web-components/who-is-online/components/types.ts
@@ -35,3 +35,12 @@ export interface LocalParticipantData {
   color: string;
   joinedPresence: boolean;
 }
+
+export interface TooltipData {
+  name: string;
+  action?: string;
+}
+
+export type VerticalSide = 'top' | 'bottom';
+
+export type HorizontalSide = 'left' | 'right';

--- a/src/web-components/who-is-online/components/types.ts
+++ b/src/web-components/who-is-online/components/types.ts
@@ -33,4 +33,5 @@ export enum PositionOptions {
 export interface LocalParticipantData {
   id: string;
   color: string;
+  joinedPresence: boolean;
 }

--- a/src/web-components/who-is-online/css/who-is-online-style.ts
+++ b/src/web-components/who-is-online/css/who-is-online-style.ts
@@ -12,6 +12,7 @@ export const whoIsOnlineStyle = css`
     display: flex;
     flex-direction: column;
     position: fixed;
+    z-index: 99;
   }
 
   .superviz-who-is-online__participant {

--- a/src/web-components/who-is-online/who-is-online.ts
+++ b/src/web-components/who-is-online/who-is-online.ts
@@ -7,7 +7,7 @@ import { RealtimeEvent } from '../../common/types/events.types';
 import { Participant } from '../../components/who-is-online/types';
 import { WebComponentsBase } from '../base';
 
-import type { LocalParticipantData } from './components/types';
+import type { LocalParticipantData, TooltipData } from './components/types';
 import { Following, WIODropdownOptions } from './components/types';
 import { whoIsOnlineStyle } from './css/index';
 
@@ -320,9 +320,9 @@ export class WhoIsOnline extends WebComponentsBaseElement {
           const append = isLocal ? ' (you)' : '';
           const participantName = name + append;
 
-          const tooltipData = {
+          const tooltipData: TooltipData = {
             name,
-          } as { name: string; action: string };
+          };
 
           if (this.localParticipantData?.joinedPresence && joinedPresence && !isLocal) {
             tooltipData.action = 'Click to Follow';

--- a/src/web-components/who-is-online/who-is-online.ts
+++ b/src/web-components/who-is-online/who-is-online.ts
@@ -113,6 +113,7 @@ export class WhoIsOnline extends WebComponentsBaseElement {
         ?showSeeMoreTooltip=${this.showTooltip}
         @toggle=${this.toggleOpen}
         @toggle-dropdown-state=${this.toggleShowTooltip}
+        ?localParticipantJoinedPresence=${this.localParticipantData?.joinedPresence}
       >
         <div class=${classMap(classes)} slot="dropdown">
           <div class="superviz-who-is-online__excess" style="color: #AEA9B8;">+${excess}</div>
@@ -319,6 +320,18 @@ export class WhoIsOnline extends WebComponentsBaseElement {
           const append = isLocal ? ' (you)' : '';
           const participantName = name + append;
 
+          const tooltipData = {
+            name,
+          } as { name: string; action: string };
+
+          if (this.localParticipantData?.joinedPresence && joinedPresence && !isLocal) {
+            tooltipData.action = 'Click to Follow';
+          }
+
+          if (isLocal) {
+            tooltipData.action = 'You';
+          }
+
           return html`
             <superviz-dropdown
               options=${JSON.stringify(options)}
@@ -330,7 +343,7 @@ export class WhoIsOnline extends WebComponentsBaseElement {
               name="${participantName}"
               ?disabled=${disableDropdown}
               ?canShowTooltip=${this.showTooltip}
-              onHoverData=${JSON.stringify({ name, action: isLocal ? 'You' : 'Click to follow' })}
+              onHoverData=${JSON.stringify(tooltipData)}
             >
               <div slot="dropdown" class=${classMap(classList)} style="--border-color: ${color}">
                 ${this.getAvatar(participant)}


### PR DESCRIPTION
Now, if either local participant or another participant is not in Presence, do not show 'Click to Follow' when hovering over other participant avatar. Besides, the mouse pointers of other participants in Presence do not show over WIO avatars and dropdown anymore.