### PR TITLE
feat: render cursor with css

### DIFF
--- a/src/components/comments/canvas-pin-adapter/index.test.ts
+++ b/src/components/comments/canvas-pin-adapter/index.test.ts
@@ -183,6 +183,9 @@ describe('CanvasPinAdapter', () => {
     const canvasPinAdapter = new CanvasPin('canvas');
     canvasPinAdapter.setActive(true);
     expect(canvasPinAdapter).toBeInstanceOf(CanvasPin);
+    expect(canvasPinAdapter['canvas'].style.cursor).toBe(
+      'url("https://production.cdn.superviz.com/static/pin-html.png") 0 100, pointer',
+    );
   });
 
   test('should throw an error if no canvas element is found', () => {
@@ -194,7 +197,7 @@ describe('CanvasPinAdapter', () => {
   test('should add event listeners to the canvas element', () => {
     const addEventListenerSpy = jest.spyOn(instance['canvas'], 'addEventListener');
     instance['addListeners']();
-    expect(addEventListenerSpy).toHaveBeenCalledTimes(5);
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(2);
   });
 
   test('should destroy the canvas pin adapter', () => {
@@ -202,29 +205,7 @@ describe('CanvasPinAdapter', () => {
 
     instance.destroy();
 
-    expect(instance['mouseElement']).toBeNull();
-    expect(removeEventListenerSpy).toHaveBeenCalledTimes(5);
-  });
-
-  test('when mouse enters canvas, should create a new mouse element', () => {
-    const canvasPinAdapter = new CanvasPin('canvas');
-    canvasPinAdapter.setActive(true);
-    const mock = jest.fn().mockImplementation(() => document.createElement('div'));
-    canvasPinAdapter['createMouseElement'] = mock;
-
-    canvasPinAdapter['canvas'].dispatchEvent(new MouseEvent('mouseenter'));
-
-    expect(canvasPinAdapter['createMouseElement']).toHaveBeenCalledTimes(1);
-  });
-
-  test('when mouse leaves canvas, should remove the mouse element', () => {
-    const canvasPinAdapter = new CanvasPin('canvas');
-    canvasPinAdapter.setActive(true);
-
-    canvasPinAdapter['canvas'].dispatchEvent(new MouseEvent('mouseenter'));
-    canvasPinAdapter['canvas'].dispatchEvent(new MouseEvent('mouseout'));
-
-    expect(canvasPinAdapter['mouseElement']).toBeNull();
+    expect(removeEventListenerSpy).toHaveBeenCalledTimes(2);
   });
 
   test('should create temporary pin when mouse clicks canvas', () => {
@@ -356,21 +337,6 @@ describe('CanvasPinAdapter', () => {
     instance.updateAnnotations([]);
 
     expect(instance['pins'].size).toEqual(0);
-  });
-
-  test('should update the position of the mouse element', () => {
-    const event = new MouseEvent('mousemove', { clientX: 100, clientY: 200 });
-    const customEvent = {
-      ...event,
-      x: event.clientX,
-      y: event.clientY,
-    };
-
-    instance['onMouseMove'](customEvent);
-
-    const element = instance['mouseElement'];
-    expect(element).toBeDefined();
-    expect(element.getAttribute('position')).toBe(JSON.stringify({ x: 100, y: 200 }));
   });
 
   test('should update mouse coordinates on mousedown event', () => {

--- a/src/components/comments/canvas-pin-adapter/index.ts
+++ b/src/components/comments/canvas-pin-adapter/index.ts
@@ -97,6 +97,7 @@ export class CanvasPin implements PinAdapter {
       return;
     }
 
+    this.resetPins();
     this.removeListeners();
     this.canvas.style.cursor = this.originalCanvasCursor;
   }

--- a/src/components/comments/canvas-pin-adapter/index.ts
+++ b/src/components/comments/canvas-pin-adapter/index.ts
@@ -9,7 +9,6 @@ export class CanvasPin implements PinAdapter {
   private canvas: HTMLCanvasElement;
   private canvasSides: CanvasSides;
   private divWrapper: HTMLElement;
-  private mouseElement: HTMLElement;
   private isActive: boolean;
   private isPinsVisible: boolean = true;
   private annotations: Annotation[];
@@ -23,6 +22,7 @@ export class CanvasPin implements PinAdapter {
   private commentsSide: 'left' | 'right' = 'left';
   private movedTemporaryPin: boolean;
   private localParticipant: SimpleParticipant = {};
+  private originalCanvasCursor: string;
 
   constructor(
     canvasId: string,
@@ -59,7 +59,6 @@ export class CanvasPin implements PinAdapter {
   public destroy(): void {
     this.removeListeners();
     this.removeAnnotationsPins();
-    this.mouseElement = null;
     this.pins = new Map();
     this.divWrapper.remove();
     this.onPinFixedObserver.destroy();
@@ -88,14 +87,18 @@ export class CanvasPin implements PinAdapter {
    */
   public setActive(isOpen: boolean): void {
     this.isActive = isOpen;
-    this.canvas.style.cursor = isOpen ? 'none' : 'default';
+    // this.canvas.style.cursor = isOpen ? 'none' : 'default';
 
     if (this.isActive) {
+      this.originalCanvasCursor = this.canvas.style.cursor;
+      this.canvas.style.cursor =
+        'url("https://production.cdn.superviz.com/static/pin-html.png") 0 100, pointer';
       this.addListeners();
       return;
     }
 
     this.removeListeners();
+    this.canvas.style.cursor = this.originalCanvasCursor;
   }
 
   /**
@@ -179,9 +182,6 @@ export class CanvasPin implements PinAdapter {
   private addListeners(): void {
     this.canvas.addEventListener('click', this.onClick);
     this.canvas.addEventListener('mousedown', this.setMouseDownCoordinates);
-    this.canvas.addEventListener('mousemove', this.onMouseMove);
-    this.canvas.addEventListener('mouseout', this.onMouseLeave);
-    this.canvas.addEventListener('mouseenter', this.onMouseEnter);
     document.body.addEventListener('keyup', this.resetPins);
     document.body.addEventListener('select-annotation', this.annotationSelected);
     document.body.addEventListener('toggle-annotation-sidebar', this.onToggleAnnotationSidebar);
@@ -201,29 +201,9 @@ export class CanvasPin implements PinAdapter {
   private removeListeners(): void {
     this.canvas.removeEventListener('click', this.onClick);
     this.canvas.removeEventListener('mousedown', this.setMouseDownCoordinates);
-    this.canvas.removeEventListener('mousemove', this.onMouseMove);
-    this.canvas.removeEventListener('mouseout', this.onMouseLeave);
-    this.canvas.removeEventListener('mouseenter', this.onMouseEnter);
     document.body.removeEventListener('keyup', this.resetPins);
     document.body.removeEventListener('select-annotation', this.annotationSelected);
     document.body.removeEventListener('toggle-annotation-sidebar', this.onToggleAnnotationSidebar);
-  }
-
-  /**
-   * @function createMouseElement
-   * @description Creates a new mouse element for the canvas pin adapter.
-   * @returns {HTMLElement} The newly created mouse element.
-   */
-  private createMouseElement(): HTMLElement {
-    const mouseElement = document.createElement('superviz-comments-annotation-pin');
-    mouseElement.setAttribute('type', PinMode.ADD);
-    mouseElement.setAttribute('annotation', JSON.stringify({}));
-    mouseElement.setAttribute('position', JSON.stringify({ x: 0, y: 0 }));
-    document.body.appendChild(mouseElement);
-
-    this.canvas.style.cursor = 'none';
-
-    return mouseElement;
   }
 
   /**
@@ -481,51 +461,6 @@ export class CanvasPin implements PinAdapter {
     if (this.selectedPin) return;
 
     document.body.dispatchEvent(new CustomEvent('unselect-annotation'));
-  };
-
-  /**
-   * @function onMouseMove
-   * @description handles the mouse move event on the canvas.
-   * @param event - The mouse event object.
-   * @returns {void}
-   */
-  private onMouseMove = (event: MouseEvent): void => {
-    const { x, y } = event;
-
-    if (!this.mouseElement) {
-      this.mouseElement = this.createMouseElement();
-    }
-
-    this.mouseElement.setAttribute('position', JSON.stringify({ x, y }));
-  };
-
-  /**
-   * @function onMouseLeave
-   * @description
-      Removes the mouse element and sets the canvas cursor
-      to default when the mouse leaves the canvas.
-   * @returns {void}
-   */
-  private onMouseLeave = (): void => {
-    if (this.mouseElement) {
-      this.mouseElement.remove();
-      this.mouseElement = null;
-    }
-
-    this.canvas.style.cursor = 'default';
-  };
-
-  /**
-   * @function onMouseEnter
-   * @description
-        Handles the mouse enter event for the canvas pin adapter.
-        If there is no mouse element, creates one.
-   * @returns {void}
-   */
-  private onMouseEnter = (): void => {
-    if (this.mouseElement) return;
-
-    this.mouseElement = this.createMouseElement();
   };
 
   /**


### PR DESCRIPTION
Use CSS to render our mouse cursor, instead of creating a HTML element to do this
![image](https://github.com/SuperViz/sdk/assets/111044527/dc8f8786-e984-461e-bfc9-8fe831715f4d)

As a bonus, when closing the sidebar, the temporary pin now disappears and any selected pin is unselected. I could swear this already happened, but empirical observations proved that that was not the case