### PR TITLE
feat: comments v3

### DIFF
--- a/src/common/types/events.types.ts
+++ b/src/common/types/events.types.ts
@@ -121,6 +121,11 @@ export enum DeviceEvent {
   DEVICES_ALLOWED = 'devices.allowed',
 }
 
+export enum CommentEvent {
+  pinActive = 'pin-mode.active',
+  pinInactive = 'pin-mode.inactive',
+}
+
 export type Dimensions = {
   width: number | null;
   height: number | null;

--- a/src/common/types/events.types.ts
+++ b/src/common/types/events.types.ts
@@ -122,8 +122,8 @@ export enum DeviceEvent {
 }
 
 export enum CommentEvent {
-  pinActive = 'pin-mode.active',
-  pinInactive = 'pin-mode.inactive',
+  PIN_ACTIVE = 'pin-mode.active',
+  PIN_INACTIVE = 'pin-mode.inactive',
 }
 
 export type Dimensions = {

--- a/src/components/comments/index.ts
+++ b/src/components/comments/index.ts
@@ -75,7 +75,7 @@ export class Comments extends BaseComponent {
   };
 
   /**
-   * @function openThreads
+   * @function closeThreads
    * @description - Close comments thread
    * @returns {void}
    */
@@ -187,7 +187,7 @@ export class Comments extends BaseComponent {
     this.button?.addEventListener('toggle', this.togglePinActive);
 
     // Comments component observers
-    this.element.addEventListener('toggle', this.togglePinActive);
+    this.element.addEventListener('close', this.closeThreads);
     document.body.addEventListener('create-annotation', this.createAnnotation);
     this.element.addEventListener('resolve-annotation', this.resolveAnnotation);
     this.element.addEventListener('delete-annotation', this.deleteAnnotation);
@@ -217,7 +217,7 @@ export class Comments extends BaseComponent {
     this.button?.removeEventListener('toggle', this.togglePinActive);
 
     // Comments component observers
-    this.element.removeEventListener('toggle', this.togglePinActive);
+    this.element.removeEventListener('close', this.closeThreads);
     this.element.removeEventListener('create-annotation', this.createAnnotation);
     this.element.removeEventListener('resolve-annotation', this.resolveAnnotation);
     this.element.removeEventListener('create-comment', ({ detail }: CustomEvent) => {

--- a/src/components/comments/index.ts
+++ b/src/components/comments/index.ts
@@ -1,3 +1,4 @@
+import { CommentEvent } from '../../common/types/events.types';
 import { Logger } from '../../common/utils';
 import ApiService from '../../services/api';
 import config from '../../services/config';
@@ -66,6 +67,22 @@ export class Comments extends BaseComponent {
   public closeThreads = (): void => {
     this.element?.removeAttribute('open');
   };
+
+  /**
+   * @function enable
+   */
+  public enable() {
+    this.pinAdapter.setActive(true);
+    this.publish(CommentEvent.pinActive);
+  }
+
+  /**
+   * @function disable
+   */
+  public disable() {
+    this.pinAdapter.setActive(false);
+    this.publish(CommentEvent.pinInactive);
+  }
 
   /**
    * @function url

--- a/src/components/comments/index.ts
+++ b/src/components/comments/index.ts
@@ -96,8 +96,10 @@ export class Comments extends BaseComponent {
 
   /**
    * @function enable
+   * @description - Activates the pin adapter and allows the user to create annotations
+   * @returns {void}
    */
-  public enable() {
+  public enable(): void {
     this.pinAdapter.setActive(true);
     this.pinActive = true;
     this.publish(CommentEvent.pinActive);
@@ -105,8 +107,10 @@ export class Comments extends BaseComponent {
 
   /**
    * @function disable
+   * @description - Deactivates the pin adapter and prevents the user from creating annotations
+   * @returns {void}
    */
-  public disable() {
+  public disable(): void {
     this.pinAdapter.setActive(false);
     this.pinActive = false;
     this.publish(CommentEvent.pinInactive);
@@ -146,10 +150,16 @@ export class Comments extends BaseComponent {
 
   /**
    * @function togglePinActive
+   * @description Toggles the pin adapter's active state
+   * @returns {void}
    */
-  public togglePinActive = () => {
-    this.pinActive = !this.pinActive;
-    this.pinAdapter.setActive(this.pinActive);
+  public togglePinActive = (): void => {
+    if (this.pinActive) {
+      this.disable();
+      return;
+    }
+
+    this.enable();
   };
 
   /**

--- a/src/components/comments/index.ts
+++ b/src/components/comments/index.ts
@@ -102,7 +102,7 @@ export class Comments extends BaseComponent {
   public enable(): void {
     this.pinAdapter.setActive(true);
     this.pinActive = true;
-    this.publish(CommentEvent.pinActive);
+    this.publish(CommentEvent.PIN_ACTIVE);
   }
 
   /**
@@ -113,7 +113,7 @@ export class Comments extends BaseComponent {
   public disable(): void {
     this.pinAdapter.setActive(false);
     this.pinActive = false;
-    this.publish(CommentEvent.pinInactive);
+    this.publish(CommentEvent.PIN_INACTIVE);
   }
 
   /**

--- a/src/components/comments/index.ts
+++ b/src/components/comments/index.ts
@@ -50,6 +50,24 @@ export class Comments extends BaseComponent {
   }
 
   /**
+   * @function openThreads
+   * @description - Open comments thread
+   * @returns {void}
+   */
+  public openThreads = (): void => {
+    this.element?.setAttribute('open', '');
+  };
+
+  /**
+   * @function openThreads
+   * @description - Close comments thread
+   * @returns {void}
+   */
+  public closeThreads = (): void => {
+    this.element?.removeAttribute('open');
+  };
+
+  /**
    * @function url
    * @description Gets the URL of the client
    * @returns {void}

--- a/src/components/comments/types.ts
+++ b/src/components/comments/types.ts
@@ -60,4 +60,5 @@ export enum ButtonLocation {
 export interface CommentsOptions {
   position?: CommentsSide | `${CommentsSide}`;
   buttonLocation?: ButtonLocation | `${ButtonLocation}` | string;
+  hideDefaultButton?: boolean;
 }

--- a/src/web-components/comments/comments.ts
+++ b/src/web-components/comments/comments.ts
@@ -41,8 +41,8 @@ export class Comments extends WebComponentsBaseElement {
     this.annotations = data;
   }
 
-  private toggle() {
-    this.emitEvent('toggle', {});
+  private close() {
+    this.emitEvent('close', {});
   }
 
   waterMarkStatus(waterMark: boolean) {
@@ -94,7 +94,7 @@ export class Comments extends WebComponentsBaseElement {
       <div id="superviz-comments" class=${containerClass}>
         <div class="header">
           <superviz-comments-topbar
-            @close=${this.toggle}
+            @close=${this.close}
             side=${this.side.split(':')[0]}
           ></superviz-comments-topbar>
         </div>

--- a/src/web-components/comments/components/topbar.ts
+++ b/src/web-components/comments/components/topbar.ts
@@ -25,7 +25,7 @@ export class CommentsTopbar extends WebComponentsBase(LitElement) {
       <div class="topbar">
         <span class="text text-bold">COMMENTS</span>
         <span @click=${this.close} class="toggle-icon">
-          <superviz-icon name=${this.side} size="lg"></superviz-icon>
+          <superviz-icon name=${this.side} allowSetSize=${true}></superviz-icon>
         </span>
       </div>
     `;

--- a/src/web-components/comments/css/topbar.style.ts
+++ b/src/web-components/comments/css/topbar.style.ts
@@ -4,20 +4,27 @@ export const topbarStyle = css`
   div.topbar {
     display: flex;
     justify-content: space-between;
+    align-items: center;
     background-color: rgb(var(--sv-gray-200));
     height: 50px;
   }
 
   div.topbar span {
-    margin: 16px;
+    margin: 0 16px;
     color: rgb(var(--sv-gray-600));
   }
 
   .toggle-icon {
     cursor: pointer;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     transition: 0.15s;
     border-radius: 50%;
-    aspect-ratio: 1;
+    width: 32px;
+    height: 32px;
+    box-sizing: border-box;
+    padding-left: 2px;
   }
 
   .toggle-icon:hover {


### PR DESCRIPTION
Instead of relying purely on our button to handle the state of comments, we now allow the user to invoke methods that opens or closes the comments threads/sidebar, as well as methods that allow add new pins to the elements or not. Our button, now, only toggles the active/inactive status of the pins (that is, if the user can add or not new pins), and there's now even a flag to hide the button.


https://github.com/SuperViz/sdk/assets/111044527/95ee8002-8ed0-46ca-b528-4d6d534781ac

