### PR TITLE
Fix: mentions dropdown list with scroll

### DIFF
--- a/src/web-components/comments/components/mention-list.test.ts
+++ b/src/web-components/comments/components/mention-list.test.ts
@@ -34,6 +34,102 @@ describe('CommentsMentionList', () => {
     expect(element.shadowRoot.getElementById('mention-list').style.display).toEqual('none'); 
   });
 
+  test('renders without participants', async () => {
+    await element.updateComplete;
+    expect(element.shadowRoot.getElementById('mention-list').style.display).toEqual('none');
+  });
+
+  test('renders with participants', async () => {
+    element.participants = MOCK_PARTICIPANT_LIST;
+    await element.updateComplete;
+
+    expect(element.shadowRoot.getElementById('mention-list').style.display).toEqual('block');
+  });
+
+  test('selects a participant and emits event', async () => {  
+    element.participants = MOCK_PARTICIPANT_LIST;
+    await element.updateComplete;
+
+    const mentionItem = element.shadowRoot.querySelector('.mention-item');
+    mentionItem.click();
+
+    element['selectParticipant'](MOCK_PARTICIPANT_LIST[0]);
+    expect(element.shadowRoot.getElementById('mention-list').style.display).toEqual('none'); 
+  });
+
+  test('should display avatar', async () => {
+    element.participants = MOCK_PARTICIPANT_LIST;
+    await element.updateComplete;
+
+    const avatar = element.shadowRoot.querySelector('.avatar');
+    expect(avatar).toBeTruthy();
+  });
+
+  test('should display default avatar', async () => {
+    element.participants = [
+      {
+        ...MOCK_PARTICIPANT_LIST[0],
+        avatar: null
+      }
+    ];
+    await element.updateComplete;
+
+    const defaultAvatar = element.shadowRoot.querySelector('.default-avatar');
+    expect(defaultAvatar).toBeTruthy();
+  });
+
+  test('should add event listener on wheel', async () => {
+    await element.updateComplete;
+    element.showMentionList();
+
+    const mentionListElement = element.shadowRoot?.getElementById('mention-list');
+    expect(mentionListElement).toBeTruthy();
+
+    expect(mentionListElement?.style.display).toEqual('block');
+
+
+    const mockHandleZoom = jest.fn();
+    element.stopHandleZoom = mockHandleZoom;
+
+    const wheelEvent = new Event('wheel');
+    mentionListElement.addEventListener('wheel', element.stopHandleZoom);
+
+    mentionListElement.dispatchEvent(wheelEvent);
+
+    await sleep();
+
+    expect(element.stopHandleZoom).toHaveBeenCalled();
+  });
+
+  test('should remove event listener', async () => {
+    await element.updateComplete;
+    element.showMentionList();
+
+    const mentionListElement = element.shadowRoot?.getElementById('mention-list');
+    expect(mentionListElement).toBeTruthy();
+    expect(mentionListElement?.style.display).toEqual('block');
+
+    element.hideMentionList();
+    expect(mentionListElement?.style.display).toEqual('none');
+
+    const mockHandleZoom = jest.fn();
+    element.stopHandleZoom = mockHandleZoom;
+
+    const wheelEvent = new Event('wheel');
+
+    mentionListElement.dispatchEvent(wheelEvent);
+
+    expect(element.stopHandleZoom).not.toHaveBeenCalled();
+  });
+
+  test('should set display mention list property to none', () => {
+    element.hideMentionList();
+
+    const mentionListElement = element.shadowRoot?.getElementById('mention-list');
+
+    expect(mentionListElement?.style.getPropertyValue('display')).toBe('none');
+  });
+
   test('should display avatar', async () => {
     element.participants = MOCK_PARTICIPANT_LIST;
     await element.updateComplete;

--- a/src/web-components/comments/components/mention-list.ts
+++ b/src/web-components/comments/components/mention-list.ts
@@ -37,10 +37,12 @@ export class CommentsMentionList extends WebComponentsBaseElement {
     const mentionList = this.shadowRoot?.getElementById('mention-list');
     mentionList?.style.setProperty('display', 'block'); 
     mentionList?.style.setProperty('margin-top', '1px');
+    mentionList.addEventListener('wheel', this.stopHandleZoom);
   }
 
   hideMentionList = () => {
     const mentionList = this.shadowRoot?.getElementById('mention-list');
+    mentionList.removeEventListener('wheel', this.stopHandleZoom);
     mentionList?.style.setProperty('display', 'none'); 
   }
 
@@ -51,6 +53,12 @@ export class CommentsMentionList extends WebComponentsBaseElement {
     })
 
     this.hideMentionList()
+  }
+
+  private stopHandleZoom = (event) => {
+    const menu = this.shadowRoot?.getElementById('mention-list');
+    menu.scrollTop += event.deltaY;
+    event.preventDefault();
   }
 
   private getAvatar(participant: ParticipantByGroupApi) {


### PR DESCRIPTION
When utilizing external events for zoom and mouse movements, the list of mentions fails to scroll.
Resolved issue with participant list scrolling despite external events.