### PR TITLE
fix: remove allowSetSize property from superviz-icon component

### DIFF
--- a/src/web-components/comments/components/annotation-filter.ts
+++ b/src/web-components/comments/components/annotation-filter.ts
@@ -90,7 +90,7 @@ export class CommentsAnnotationFilter extends WebComponentsBaseElement {
           >
             <div class="comments__filter__toggle-button" slot="dropdown">
               <span class=${classMap(textClasses)}>${selectedLabel}</span>
-              <superviz-icon name=${this.caret} size="md"></superviz-icon>
+              <superviz-icon name=${this.caret} size="xs"></superviz-icon>
             </div>
           </superviz-dropdown>
         </div>

--- a/src/web-components/comments/components/annotation-pin.ts
+++ b/src/web-components/comments/components/annotation-pin.ts
@@ -194,7 +194,7 @@ export class CommentsAnnotationPin extends WebComponentsBaseElement {
       return html`<div
         class="comments__annotation-pin__avatar comments__annotation-pin__avatar--add"
       >
-        <superviz-icon name="add" allowSetSize="true"></superviz-icon>
+        <superviz-icon name="add"></superviz-icon>
       </div>`;
     }
 

--- a/src/web-components/comments/components/comment-input.ts
+++ b/src/web-components/comments/components/comment-input.ts
@@ -352,7 +352,7 @@ export class CommentsCommentInput extends WebComponentsBaseElement {
 
       return html`
         <button class="comments__input__send-button align-send-btn" disabled @click=${this.send}>
-          <superviz-icon name="line-arrow-right" size="sm" allowSetSize=${true}></superviz-icon>
+          <superviz-icon name="line-arrow-right" size="sm"></superviz-icon>
         </button>
       `;
     };
@@ -379,7 +379,6 @@ export class CommentsCommentInput extends WebComponentsBaseElement {
               name="mention"
               @click=${this.addAtSymbolInCaretPosition}
               size="sm"
-              allowSetSize=${true}
             ></superviz-icon>
           </button>
           <div class="comment-input-options">

--- a/src/web-components/comments/components/comment-item.ts
+++ b/src/web-components/comments/components/comment-item.ts
@@ -225,7 +225,7 @@ export class CommentsCommentItem extends WebComponentsBaseElement {
                 'resolve-icon',
               )} icon-button icon-button--clickable icon-button--xsmall ${isResolvable}"
             >
-              <superviz-icon name=${resolveIcon} size="md"></superviz-icon>
+              <superviz-icon name=${resolveIcon} size="sm"></superviz-icon>
             </button>
             <superviz-dropdown
               options=${JSON.stringify(options)}

--- a/src/web-components/comments/components/float-button.ts
+++ b/src/web-components/comments/components/float-button.ts
@@ -81,7 +81,6 @@ export class CommentsFloatButton extends WebComponentsBaseElement {
 
     return html` <button @click=${this.toggle} class="${classMap(floatButtonClasses)}">
       <superviz-icon
-        allowSetSize=${true}
         size="sm"
         name="comment"
         class="comments__floating-button__icon"

--- a/src/web-components/comments/components/topbar.ts
+++ b/src/web-components/comments/components/topbar.ts
@@ -35,7 +35,7 @@ export class CommentsTopbar extends WebComponentsBase(LitElement) {
       <div class="comments__topbar">
         <span class="text text-bold comments__topbar__title">COMMENTS</span>
         <span @click=${this.close} class="comments__topbar__close-threads">
-          <superviz-icon name=${this.side} allowSetSize=${true}></superviz-icon>
+          <superviz-icon name=${this.side}></superviz-icon>
         </span>
       </div>
     `;

--- a/src/web-components/dropdown/index.ts
+++ b/src/web-components/dropdown/index.ts
@@ -225,7 +225,7 @@ export class Dropdown extends WebComponentsBaseElement {
 
   private get supervizIcons() {
     return this.icons?.map((icon) => {
-      return html`<superviz-icon allowSetSize=${true} name="${icon}" size="sm"></superviz-icon>`;
+      return html`<superviz-icon name="${icon}" size="sm"></superviz-icon>`;
     });
   }
 

--- a/src/web-components/icon/index.ts
+++ b/src/web-components/icon/index.ts
@@ -12,7 +12,6 @@ const styles: CSSResultGroup[] = [WebComponentsBaseElement.styles];
 export class Icon extends WebComponentsBaseElement {
   declare name: string;
   declare size: string;
-  declare allowSetSize: boolean;
 
   constructor() {
     super();
@@ -24,11 +23,9 @@ export class Icon extends WebComponentsBaseElement {
   static properties = {
     name: { type: String },
     size: { type: String },
-    allowSetSize: { type: Boolean },
   };
 
   private get iconSize(): string {
-    if (!this.allowSetSize) return;
     return IconSizes[this.size];
   }
 

--- a/src/web-components/modal/modal-container.test.ts
+++ b/src/web-components/modal/modal-container.test.ts
@@ -14,14 +14,16 @@ const createEl = (options: ModalOptions): HTMLElement => {
 
 describe('modal-container', () => {
   afterEach(() => {
-    document.body.querySelector('superviz-modal')
-      ?.remove();
+    document.body.querySelector('superviz-modal')?.remove();
   });
 
   test('should render modal container when open is true', async () => {
     const element = createEl({
       title: 'DELETE COMMENT',
-      body: html`<span class="text text-big">Are you sure you want to delete this comment? <br /> This action cannot be undone</span>`,
+      body: html`<span class="text text-big"
+        >Are you sure you want to delete this comment? <br />
+        This action cannot be undone</span
+      >`,
       confirmLabel: 'DELETE',
       confirm: true,
       cancel: true,
@@ -35,7 +37,10 @@ describe('modal-container', () => {
   test('should render title in header', async () => {
     const element = createEl({
       title: 'DELETE COMMENT',
-      body: html`<span class="text text-big">Are you sure you want to delete this comment? <br /> This action cannot be undone</span>`,
+      body: html`<span class="text text-big"
+        >Are you sure you want to delete this comment? <br />
+        This action cannot be undone</span
+      >`,
       confirmLabel: 'DELETE',
       confirm: true,
       cancel: true,
@@ -51,7 +56,10 @@ describe('modal-container', () => {
   test('should render body', async () => {
     const element = createEl({
       title: 'DELETE COMMENT',
-      body: html`<span class="text text-big">Are you sure you want to delete this comment? <br /> This action cannot be undone</span>`,
+      body: html`<span class="text text-big"
+        >Are you sure you want to delete this comment? <br />
+        This action cannot be undone</span
+      >`,
       confirmLabel: 'DELETE',
       confirm: true,
       cancel: true,
@@ -59,15 +67,22 @@ describe('modal-container', () => {
 
     await sleep(100);
 
-    const body = element?.shadowRoot?.querySelector('.modal--body .modal--body-content')?.textContent;
+    const body = element?.shadowRoot?.querySelector(
+      '.modal--body .modal--body-content',
+    )?.textContent;
 
-    expect(body?.trim()).toBe('Are you sure you want to delete this comment?  This action cannot be undone');
+    expect(body?.trim().replace('  ', ' ').replace('\n', '')).toBe(
+      'Are you sure you want to delete this comment?        This action cannot be undone',
+    );
   });
 
   test('should render footer', async () => {
     const element = createEl({
       title: 'DELETE COMMENT',
-      body: html`<span class="text text-big">Are you sure you want to delete this comment? <br /> This action cannot be undone</span>`,
+      body: html`<span class="text text-big"
+        >Are you sure you want to delete this comment? <br />
+        This action cannot be undone</span
+      >`,
     });
 
     await sleep(100);
@@ -80,7 +95,10 @@ describe('modal-container', () => {
   test('should render confirm button', async () => {
     const element = createEl({
       title: 'DELETE COMMENT',
-      body: html`<span class="text text-big">Are you sure you want to delete this comment? <br /> This action cannot be undone</span>`,
+      body: html`<span class="text text-big"
+        >Are you sure you want to delete this comment? <br />
+        This action cannot be undone</span
+      >`,
       confirm: true,
     });
 
@@ -94,7 +112,10 @@ describe('modal-container', () => {
   test('should render confirm and cancel button', async () => {
     const element = createEl({
       title: 'DELETE COMMENT',
-      body: html`<span class="text text-big">Are you sure you want to delete this comment? <br /> This action cannot be undone</span>`,
+      body: html`<span class="text text-big"
+        >Are you sure you want to delete this comment? <br />
+        This action cannot be undone</span
+      >`,
       confirm: true,
       cancel: true,
     });
@@ -111,7 +132,10 @@ describe('modal-container', () => {
   test('should render confirm and cancel button with custom label', async () => {
     const element = createEl({
       title: 'DELETE COMMENT',
-      body: html`<span class="text text-big">Are you sure you want to delete this comment? <br /> This action cannot be undone</span>`,
+      body: html`<span class="text text-big"
+        >Are you sure you want to delete this comment? <br />
+        This action cannot be undone</span
+      >`,
       confirmLabel: 'DELETE',
       cancelLabel: 'CANCEL',
       confirm: true,
@@ -123,14 +147,17 @@ describe('modal-container', () => {
     const confirm = element?.shadowRoot?.querySelector('.modal--footer .btn--confirm');
     const cancel = element?.shadowRoot?.querySelector('.modal--footer .btn--cancel');
 
-    expect(confirm?.textContent).toEqual('DELETE');
-    expect(cancel?.textContent).toEqual('CANCEL');
+    expect(confirm?.textContent?.trim()).toEqual('DELETE');
+    expect(cancel?.textContent?.trim()).toEqual('CANCEL');
   });
 
   test('should close modal when click on close button', async () => {
     const element = createEl({
       title: 'DELETE COMMENT',
-      body: html`<span class="text text-big">Are you sure you want to delete this comment? <br /> This action cannot be undone</span>`,
+      body: html`<span class="text text-big"
+        >Are you sure you want to delete this comment? <br />
+        This action cannot be undone</span
+      >`,
       confirm: true,
       cancel: true,
     });
@@ -149,7 +176,10 @@ describe('modal-container', () => {
   test('should close modal when click on cancel button', async () => {
     const element = createEl({
       title: 'DELETE COMMENT',
-      body: html`<span class="text text-big">Are you sure you want to delete this comment? <br /> This action cannot be undone</span>`,
+      body: html`<span class="text text-big"
+        >Are you sure you want to delete this comment? <br />
+        This action cannot be undone</span
+      >`,
       confirm: true,
       cancel: true,
     });
@@ -168,7 +198,10 @@ describe('modal-container', () => {
   test('should confirm modal when click on confirm button', async () => {
     const element = createEl({
       title: 'DELETE COMMENT',
-      body: html`<span class="text text-big">Are you sure you want to delete this comment? <br /> This action cannot be undone</span>`,
+      body: html`<span class="text text-big"
+        >Are you sure you want to delete this comment? <br />
+        This action cannot be undone</span
+      >`,
       confirm: true,
       cancel: true,
     });

--- a/src/web-components/modal/modal-container.ts
+++ b/src/web-components/modal/modal-container.ts
@@ -20,17 +20,21 @@ export class ModalContainer extends WebComponentsBaseElement {
   }
 
   private closeModal = () => {
-    window.document.body.dispatchEvent(new CustomEvent('superviz-modal--close', {
-      bubbles: true,
-      composed: true,
-    }));
+    window.document.body.dispatchEvent(
+      new CustomEvent('superviz-modal--close', {
+        bubbles: true,
+        composed: true,
+      }),
+    );
   };
 
   private confirmModal = () => {
-    window.document.body.dispatchEvent(new CustomEvent('superviz-modal--confirm', {
-      bubbles: true,
-      composed: true,
-    }));
+    window.document.body.dispatchEvent(
+      new CustomEvent('superviz-modal--confirm', {
+        bubbles: true,
+        composed: true,
+      }),
+    );
   };
 
   protected render() {
@@ -48,20 +52,14 @@ export class ModalContainer extends WebComponentsBaseElement {
     const body = () => {
       return html`
         <div class="modal--body">
-          <div class="modal--body-content">
-            ${this.options.body}
-          </div>
+          <div class="modal--body-content">${this.options.body}</div>
         </div>
       `;
     };
 
     const footer = () => {
       if (this.options.footer) {
-        return html`
-          <div class="modal--footer">
-            ${this.options.footer}
-          </div>
-        `;
+        return html` <div class="modal--footer">${this.options.footer}</div> `;
       }
 
       const confirmLabel = this.options.confirmLabel || 'OK';
@@ -70,15 +68,21 @@ export class ModalContainer extends WebComponentsBaseElement {
       if (this.options.confirm && this.options.cancel) {
         return html`
           <div class="modal--footer">
-            <button class="text text-bold btn btn--cancel" @click=${this.closeModal}>${cancelLabel}</button>
-            <button class="text text-bold btn btn--confirm" @click=${this.confirmModal}>${confirmLabel}</button>
+            <button class="text text-bold btn btn--cancel" @click=${this.closeModal}>
+              ${cancelLabel}
+            </button>
+            <button class="text text-bold btn btn--confirm" @click=${this.confirmModal}>
+              ${confirmLabel}
+            </button>
           </div>
         `;
       }
 
       return html`
         <div class="modal--footer">
-          <button class="text text-bold btn btn--confirm" @click=${this.confirmModal}>${confirmLabel}</button>
+          <button class="text text-bold btn btn--confirm" @click=${this.confirmModal}>
+            ${confirmLabel}
+          </button>
         </div>
       `;
     };
@@ -86,13 +90,7 @@ export class ModalContainer extends WebComponentsBaseElement {
     return html`
       <div class="modal--overlay"></div>
       <div class="modal--container">
-        <div class="modal">
-          ${header()}
-
-          ${body()}
-
-          ${footer()}
-        </div>
+        <div class="modal">${header()} ${body()} ${footer()}</div>
       </div>
     `;
   }

--- a/src/web-components/who-is-online/components/dropdown.ts
+++ b/src/web-components/who-is-online/components/dropdown.ts
@@ -228,7 +228,9 @@ export class WhoIsOnlineDropdown extends WebComponentsBaseElement {
             <superviz-icon 
               class=${classMap(iconClasses)} 
               name="right" 
-              color="var(--sv-gray-600)">
+              color="var(--sv-gray-600)"
+              size="sm"
+            >
           </superviz-icon>
           </div>
         </div>

--- a/src/web-components/who-is-online/css/dropdown.style.ts
+++ b/src/web-components/who-is-online/css/dropdown.style.ts
@@ -82,6 +82,12 @@ export const dropdownStyle = css`
     overflow: auto;
   }
 
+  .who-is-online__extras__arrow-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
   .menu--bottom {
     top: 4px;
     min-width: 103px;


### PR DESCRIPTION
Remove flag allowSetSize from <superviz-icon>
In the past, it was added to buy time, since a few changes made in the component meant that all the icons that we use could potentially break, appearing larger or smaller than they should be. Since reviewing this was not a priority, adding this flag was a simple, quicky, dirty solution