### PR TITLE
feat: mouse follow and wio flag

### DIFF
--- a/src/common/types/stores.types.ts
+++ b/src/common/types/stores.types.ts
@@ -1,5 +1,6 @@
 import { useGlobalStore } from '../../services/stores';
 import { PublicSubject } from '../../services/stores/common/types';
+import { useWhoIsOnlineStore } from '../../services/stores/who-is-online/index';
 
 export enum StoreType {
   GLOBAL = 'global-store',
@@ -18,5 +19,9 @@ type StoreApi<T extends (...args: any[]) => any> = {
 // When creating new Stores, expand the ternary with the new Store. For example:
 // ...T extends StoreType.GLOBAL ? StoreApi<typeof useGlobalStore> : T extends StoreType.WHO_IS_ONLINE ? StoreApi<typeof useWhoIsOnlineStore> : never;
 // Yes, it will be a little bit verbose, but it's not like we'll be creating more and more Stores just for. Rarely will someone need to come here
-export type Store<T> = T extends StoreType.GLOBAL ? StoreApi<typeof useGlobalStore> : never;
+export type Store<T> = T extends StoreType.GLOBAL
+  ? StoreApi<typeof useGlobalStore>
+  : T extends StoreType.WHO_IS_ONLINE
+  ? StoreApi<typeof useWhoIsOnlineStore>
+  : never;
 export type StoresTypes = typeof StoreType;

--- a/src/common/utils/use-store.ts
+++ b/src/common/utils/use-store.ts
@@ -1,9 +1,11 @@
 import { PublicSubject } from '../../services/stores/common/types';
 import { useGlobalStore } from '../../services/stores/global';
+import { useWhoIsOnlineStore } from '../../services/stores/who-is-online';
 import { Store, StoreType } from '../types/stores.types';
 
 const stores = {
   [StoreType.GLOBAL]: useGlobalStore,
+  [StoreType.WHO_IS_ONLINE]: useWhoIsOnlineStore,
 };
 
 /**
@@ -19,16 +21,16 @@ function subscribeTo<T>(
   callback?: (value: T) => void,
 ): void {
   subject.subscribe(this, () => {
-    this[name] = subject.value;
-
     if (callback) {
       callback(subject.value);
+    } else {
+      this[name] = subject.value;
     }
+
+    if (this.requestUpdate) this.requestUpdate();
   });
 
   this.unsubscribeFrom.push(subject.unsubscribe);
-
-  if (this.requestUpdate) this.requestUpdate();
 }
 
 /**

--- a/src/components/presence-mouse/html/index.ts
+++ b/src/components/presence-mouse/html/index.ts
@@ -205,7 +205,10 @@ export class PointersHTML extends BaseComponent {
     if (!pointer) return;
 
     if (this.goToPresenceCallback) {
-      const { x, y } = this.mouses.get(id).getBoundingClientRect();
+      const mouse = this.mouses.get(id);
+      const x = Number(mouse.style.left.replace('px', ''));
+      const y = Number(mouse.style.top.replace('px', ''));
+
       this.goToPresenceCallback({ x, y });
       return;
     }
@@ -491,6 +494,7 @@ export class PointersHTML extends BaseComponent {
    */
   public transform(transformation: Transform) {
     this.transformation = transformation;
+    this.updateParticipantsMouses(true);
   }
 
   /**
@@ -510,7 +514,7 @@ export class PointersHTML extends BaseComponent {
     this.animationFrame = requestAnimationFrame(this.animate);
   };
 
-  private updateParticipantsMouses = (): void => {
+  private updateParticipantsMouses = (haltFollow?: boolean): void => {
     this.presences.forEach((mouse) => {
       if (mouse.id === this.localParticipant.id) return;
 
@@ -521,6 +525,8 @@ export class PointersHTML extends BaseComponent {
 
       this.renderPresenceMouses(mouse);
     });
+
+    if (haltFollow) return;
 
     const isFollowingSomeone = this.presences.has(this.userBeingFollowedId);
     if (isFollowingSomeone) {
@@ -656,7 +662,8 @@ export class PointersHTML extends BaseComponent {
       scale,
     } = this.transformation;
 
-    mouseFollower.style.transform = `translate(${baseX + x * scale}px, ${baseY + y * scale}px)`;
+    mouseFollower.style.left = `${baseX + x * scale}px`;
+    mouseFollower.style.top = `${baseY + y * scale}px`;
   };
 
   /**

--- a/src/components/who-is-online/index.ts
+++ b/src/components/who-is-online/index.ts
@@ -32,6 +32,9 @@ export class WhoIsOnline extends BaseComponent {
 
     this.position = options.position ?? Position.TOP_RIGHT;
     this.setStyles(options.styles);
+
+    const { disablePresenceControls } = this.useStore(StoreType.WHO_IS_ONLINE);
+    disablePresenceControls.publish(options.flags?.disablePresenceControls);
   }
 
   /**
@@ -136,7 +139,7 @@ export class WhoIsOnline extends BaseComponent {
    */
   private onParticipantListUpdate = (data: Record<string, AblyParticipant>): void => {
     const updatedParticipants = Object.values(data).filter(({ data }) => {
-      return data.activeComponents?.includes('whoIsOnline');
+      return data.activeComponents?.includes('whoIsOnline') || data.id === this.localParticipantId;
     });
 
     const participants = updatedParticipants
@@ -148,7 +151,6 @@ export class WhoIsOnline extends BaseComponent {
         const { color } = this.realtime.getSlotColor(slotIndex);
         const isLocal = this.localParticipantId === id;
         const joinedPresence = activeComponents.some((component) => component.includes('presence'));
-        this.setLocalData(isLocal, !joinedPresence, joinedPresence);
 
         return { name, id, slotIndex, color, isLocal, joinedPresence, avatar };
       });
@@ -162,16 +164,6 @@ export class WhoIsOnline extends BaseComponent {
 
     this.participants = participants;
     this.element.updateParticipants(this.participants);
-  };
-
-  private setLocalData = (local: boolean, disable: boolean, joinedPresence: boolean) => {
-    if (!local) return;
-
-    this.element.disableDropdown = disable;
-    this.element.localParticipantData = {
-      ...this.element.localParticipantData,
-      joinedPresence,
-    };
   };
 
   /**

--- a/src/components/who-is-online/types.ts
+++ b/src/components/who-is-online/types.ts
@@ -19,4 +19,7 @@ export type WhoIsOnlinePosition = Position | `${Position}` | string | '';
 export interface WhoIsOnlineOptions {
   position?: WhoIsOnlinePosition;
   styles?: string;
+  flags?: {
+    disablePresenceControls?: boolean;
+  }
 }

--- a/src/services/stores/who-is-online/index.ts
+++ b/src/services/stores/who-is-online/index.ts
@@ -1,4 +1,3 @@
-import { Participant } from '../../../common/types/participant.types';
 import { Singleton } from '../common/types';
 import { CreateSingleton } from '../common/utils';
 import subject from '../subject';
@@ -6,29 +5,32 @@ import subject from '../subject';
 const instance: Singleton<WhoIsOnlineStore> = CreateSingleton<WhoIsOnlineStore>();
 
 export class WhoIsOnlineStore {
-  public participantHasJoinedPresence = subject<Participant>(null);
+  public disablePresenceControls = subject<boolean>(false);
 
   constructor() {
     if (instance.value) {
-      throw new Error('CommentsStore is a singleton. There can only be one instance of it.');
+      throw new Error('WhoIsOnlineStore is a singleton. There can only be one instance of it.');
     }
 
     instance.value = this;
   }
 
   public destroy() {
-    this.participantHasJoinedPresence.destroy();
+    this.disablePresenceControls.destroy();
     instance.value = null;
   }
 }
 
 const store = new WhoIsOnlineStore();
-const participantHasJoinedPresence = store.participantHasJoinedPresence.expose();
-const destroy = store.destroy.bind(store);
+const destroy = store.destroy.bind(store) as () => void;
+
+const disablePresenceControls = store.disablePresenceControls.expose();
 
 export function useWhoIsOnlineStore() {
   return {
-    participantHasJoinedPresence,
+    disablePresenceControls,
     destroy,
   };
 }
+
+export type WhoIsOnlineStoreReturnType = ReturnType<typeof useWhoIsOnlineStore>;

--- a/src/web-components/who-is-online/components/dropdown.test.ts
+++ b/src/web-components/who-is-online/components/dropdown.test.ts
@@ -177,7 +177,7 @@ describe('who-is-online-dropdown', () => {
 
     const letter = element()?.shadowRoot?.querySelector('.who-is-online__participant__avatar');
 
-    const backgroundColor = MeetingColorsHex[mockParticipants[0].slotIndex];
+    const backgroundColor = MeetingColorsHex[mockParticipants[0].slotIndex as number];
     expect(letter?.getAttribute('style')).toBe(
       `background-color: ${backgroundColor}; color: #26242A`,
     );
@@ -218,7 +218,22 @@ describe('who-is-online-dropdown', () => {
   });
 
   test('should change selected participant when click on it', async () => {
-    createEl({ position: 'bottom', participants: mockParticipants });
+    createEl({
+      position: 'bottom',
+      participants: [
+        {
+          avatar: {
+            imageUrl: '',
+            model3DUrl: '',
+          },
+          color: MeetingColorsHex[0],
+          id: '1',
+          name: 'John Zero',
+          slotIndex: 0,
+          joinedPresence: true,
+        },
+      ],
+    });
 
     await sleep();
 
@@ -231,6 +246,22 @@ describe('who-is-online-dropdown', () => {
     await sleep();
 
     expect(element()?.['selected']).toBe(mockParticipants[0].id);
+  });
+
+  test('should not change selected participant when click on it if not in presence', async () => {
+    createEl({ position: 'bottom', participants: mockParticipants });
+
+    await sleep();
+
+    const participant = element()?.shadowRoot?.querySelector(
+      '.who-is-online__extra-participant',
+    ) as HTMLElement;
+
+    participant.click();
+
+    await sleep();
+
+    expect(element()?.['selected']).not.toBe(mockParticipants[0].id);
   });
 
   describe('repositionDropdown', () => {


### PR DESCRIPTION
- Update mouse positions immediately after using transform on them, instead of waiting for next participant interaction
- Change what coordinates exactly the HTML mouse component calls the user callback with in goToPresence (Before: Coordinates relative to the user viewport. Now: Coordinates relative to the container)
- Create flag for disabling presence controls in WIO even when using it with presence