### PR TITLE
Participant events with new IO

### DIFF
--- a/src/components/realtime/index.test.ts
+++ b/src/components/realtime/index.test.ts
@@ -135,6 +135,13 @@ describe('realtime component', () => {
   });
 
   describe('fetchHistory', () => {
+    test('should return null when the realtime is not started', async () => {
+      RealtimeComponentInstance['state'] = RealtimeComponentState.STOPPED;
+      const h = await RealtimeComponentInstance.fetchHistory();
+
+      expect(h).toEqual(null);
+    });
+
     test('should return null when the history is empty', async () => {
       const spy = jest
         .spyOn(RealtimeComponentInstance['room'], 'history' as any)

--- a/src/components/realtime/index.ts
+++ b/src/components/realtime/index.ts
@@ -59,7 +59,7 @@ export class Realtime extends BaseComponent {
     if (this.state !== RealtimeComponentState.STARTED) {
       const message = `Realtime component is not started yet. You can't publish event ${event} before start`;
       this.logger.log(message);
-      console.error(message);
+      console.warn(`[SuperViz] ${message}`);
       return;
     }
 
@@ -107,6 +107,14 @@ export class Realtime extends BaseComponent {
   public fetchHistory = async (
     eventName?: string,
   ): Promise<RealtimeMessage[] | Record<string, RealtimeMessage[]> | null> => {
+    if (this.state !== RealtimeComponentState.STARTED) {
+      const message = `Realtime component is not started yet. You can't retrieve history before start`;
+
+      this.logger.log(message);
+      console.warn(`[SuperViz] ${message}`);
+      return null;
+    }
+
     const history: RealtimeMessage[] | Record<string, RealtimeMessage[]> = await new Promise(
       (resolve, reject) => {
         const next = (data: Socket.RoomHistory) => {

--- a/src/components/who-is-online/index.ts
+++ b/src/components/who-is-online/index.ts
@@ -139,7 +139,7 @@ export class WhoIsOnline extends BaseComponent {
    */
   private onParticipantListUpdate = (data: Record<string, AblyParticipant>): void => {
     const updatedParticipants = Object.values(data).filter(({ data }) => {
-      return data.activeComponents?.includes('whoIsOnline') || data.id === this.localParticipantId;
+      return data.activeComponents?.includes('whoIsOnline');
     });
 
     const participants = updatedParticipants

--- a/src/core/launcher/index.ts
+++ b/src/core/launcher/index.ts
@@ -298,6 +298,17 @@ export class Launcher extends Observable implements DefaultLauncher {
 
     if (localParticipant && !isEqual(this.participant.value, localParticipant)) {
       this.LauncherRealtimeRoom.presence.update<Participant>(localParticipant);
+
+      this.activeComponentsInstances = this.activeComponentsInstances.filter((component) => {
+        /**
+         * @NOTE - Prevents removing all components when
+         * in the first update, activeComponents is undefined.
+         * It means we should keep all instances
+         */
+        if (!localParticipant.activeComponents) return true;
+
+        return this.activeComponents.includes(component.name);
+      });
     }
   };
 
@@ -329,6 +340,7 @@ export class Launcher extends Observable implements DefaultLauncher {
 
   private startIOC = (): void => {
     this.logger.log('launcher service @ startIOC');
+
     // retrieve the current participants in the room
     this.LauncherRealtimeRoom.presence.get((presences) => {
       presences.forEach((presence) => {
@@ -409,17 +421,6 @@ export class Launcher extends Observable implements DefaultLauncher {
       presence.id === this.participant.value.id &&
       !isEqual(this.participant.value, presence.data)
     ) {
-      this.activeComponentsInstances = this.activeComponentsInstances.filter((component) => {
-        /**
-         * @NOTE - Prevents removing all components when
-         * in the first update, activeComponents is undefined.
-         * It means we should keep all instances
-         */
-        if (!presence.data.activeComponents) return true;
-
-        return this.activeComponents.includes(component.name);
-      });
-
       this.participant.value = presence.data;
       this.publish(ParticipantEvent.LOCAL_UPDATED, presence.data);
 

--- a/src/core/launcher/index.ts
+++ b/src/core/launcher/index.ts
@@ -329,6 +329,12 @@ export class Launcher extends Observable implements DefaultLauncher {
 
   private startIOC = (): void => {
     this.logger.log('launcher service @ startIOC');
+    // retrieve the current participants in the room
+    this.LauncherRealtimeRoom.presence.get((presences) => {
+      presences.forEach((presence) => {
+        this.participants.value.set(presence.id, presence.data as Participant);
+      });
+    });
 
     this.LauncherRealtimeRoom.presence.on<Participant>(
       Socket.PresenceEvents.JOINED_ROOM,
@@ -371,6 +377,7 @@ export class Launcher extends Observable implements DefaultLauncher {
     this.logger.log('launcher service @ onParticipantJoined - local participant joined');
 
     this.publish(ParticipantEvent.LOCAL_JOINED, this.participant.value);
+    this.publish(ParticipantEvent.JOINED, this.participant.value);
   };
 
   /**


### PR DESCRIPTION

### Realtime component

Fixed a bug that occurred when trying to get the room history before the component started. Now it skips the history fetch, returns null to the client, and logs a warning to the console explaining what happened. 

### Participant joined event

When a participant joins the room, if the room has other participants who joined before him, the SDK was emitting participant joined event to them too. To fix this, we get the attendee list from the IO when the SDK is started 

### Active components

We just keep it on the old IO until we migrate all the components to the new IO. It prevents bugs and weird behavior 