### PR TITLE
feat: sync the current translate and scale in the presence mouses

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+require('jest-canvas-mock');
 
 const { MOCK_CONFIG } = require('./__mocks__/config.mock');
 const config = require('./src/services/config');

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "husky": "^8.0.3",
     "jest": "^29.7.0",
     "jest-browser-globals": "^25.1.0-beta",
+    "jest-canvas-mock": "^2.5.2",
     "jest-environment-jsdom": "^29.7.0",
     "jest-fetch-mock": "^3.0.3",
     "rimraf": "^5.0.5",

--- a/src/components/presence-mouse/canvas/index.test.ts
+++ b/src/components/presence-mouse/canvas/index.test.ts
@@ -21,6 +21,11 @@ const MOCK_MOUSE: ParticipantMouse = {
     timestamp: 1710448079918,
   },
   visible: true,
+  camera: {
+    x: 0,
+    y: 0,
+    scale: 1,
+  },
 };
 
 const participant1 = { ...MOCK_MOUSE };
@@ -90,6 +95,11 @@ describe('MousePointers on Canvas', () => {
   describe('onMyParticipantMouseMove', () => {
     test('should update my participant mouse position', () => {
       const spy = jest.spyOn(presenceMouseComponent['room']['presence'], 'update');
+      presenceMouseComponent['camera'] = {
+        x: 0,
+        y: 0,
+        scale: 1,
+      };
 
       const presenceContainerId = document.createElement('div');
       presenceMouseComponent['containerId'] = 'container';
@@ -100,6 +110,11 @@ describe('MousePointers on Canvas', () => {
 
       expect(spy).toHaveBeenCalledWith({
         ...MOCK_LOCAL_PARTICIPANT,
+        camera: {
+          x: 0,
+          y: 0,
+          scale: 1,
+        },
         x: event.x,
         y: event.y,
         visible: true,
@@ -206,6 +221,11 @@ describe('MousePointers on Canvas', () => {
           timestamp: 1710448079918,
         },
         visible: true,
+        camera: {
+          x: 0,
+          y: 0,
+          scale: 1,
+        },
       };
 
       presenceMouseComponent['onPresenceLeftRoom']({
@@ -234,6 +254,11 @@ describe('MousePointers on Canvas', () => {
           timestamp: 1710448079918,
         },
         visible: true,
+        camera: {
+          x: 0,
+          y: 0,
+          scale: 1,
+        },
       };
 
       const participant2 = MOCK_MOUSE;
@@ -267,8 +292,8 @@ describe('MousePointers on Canvas', () => {
 
       expect(presenceMouseComponent['goToMouseCallback']).toHaveBeenCalledTimes(1);
       expect(presenceMouseComponent['goToMouseCallback']).toHaveBeenCalledWith({
-        x: 20,
-        y: 20,
+        x: participant2.camera.x,
+        y: participant2.camera.y,
       });
     });
   });

--- a/src/components/presence-mouse/canvas/index.test.ts
+++ b/src/components/presence-mouse/canvas/index.test.ts
@@ -24,6 +24,10 @@ const MOCK_MOUSE: ParticipantMouse = {
   camera: {
     x: 0,
     y: 0,
+    screen: {
+      width: 1920,
+      height: 1080,
+    },
     scale: 1,
   },
 };
@@ -99,6 +103,10 @@ describe('MousePointers on Canvas', () => {
         x: 0,
         y: 0,
         scale: 1,
+        screen: {
+          width: 1920,
+          height: 1080,
+        },
       };
 
       const presenceContainerId = document.createElement('div');
@@ -114,6 +122,10 @@ describe('MousePointers on Canvas', () => {
           x: 0,
           y: 0,
           scale: 1,
+          screen: {
+            width: 1920,
+            height: 1080,
+          },
         },
         x: event.x,
         y: event.y,
@@ -225,6 +237,10 @@ describe('MousePointers on Canvas', () => {
           x: 0,
           y: 0,
           scale: 1,
+          screen: {
+            width: 1920,
+            height: 1080,
+          },
         },
       };
 
@@ -258,6 +274,10 @@ describe('MousePointers on Canvas', () => {
           x: 0,
           y: 0,
           scale: 1,
+          screen: {
+            width: 1920,
+            height: 1080,
+          },
         },
       };
 
@@ -294,6 +314,8 @@ describe('MousePointers on Canvas', () => {
       expect(presenceMouseComponent['goToMouseCallback']).toHaveBeenCalledWith({
         x: participant2.camera.x,
         y: participant2.camera.y,
+        scaleX: 0,
+        scaleY: 0,
       });
     });
   });

--- a/src/components/presence-mouse/canvas/index.ts
+++ b/src/components/presence-mouse/canvas/index.ts
@@ -413,6 +413,6 @@ export class PointersCanvas extends BaseComponent {
    * @param {Transform} transformation Which transformations to apply
    */
   public transform(transformation: Transform) {
-    console.warn('[SuperViz] - Transform only available for HTML component.');
+    console.warn('[SuperViz] - transform method not available when container is a canvas element.');
   }
 }

--- a/src/components/presence-mouse/html/index.test.ts
+++ b/src/components/presence-mouse/html/index.test.ts
@@ -43,6 +43,11 @@ describe('MousePointers on HTML', () => {
         timestamp: 1710448079918,
       },
       visible: true,
+      camera: {
+        x: 0,
+        y: 0,
+        scale: 1,
+      },
     };
 
     const participant1 = { ...MOCK_MOUSE };
@@ -461,7 +466,7 @@ describe('MousePointers on HTML', () => {
             left: 10,
             right: 100,
             top: 20,
-            bottom: 90
+            bottom: 90,
           } as any),
       );
 

--- a/src/components/presence-mouse/html/index.test.ts
+++ b/src/components/presence-mouse/html/index.test.ts
@@ -47,6 +47,10 @@ describe('MousePointers on HTML', () => {
         x: 0,
         y: 0,
         scale: 1,
+        screen: {
+          width: 1920,
+          height: 1080,
+        },
       },
     };
 

--- a/src/components/presence-mouse/html/index.test.ts
+++ b/src/components/presence-mouse/html/index.test.ts
@@ -430,7 +430,16 @@ describe('MousePointers on HTML', () => {
         x: 30,
         y: 30,
         visible: true,
-      });
+        camera: {
+          scale: 1,
+          x: 10,
+          y: 10,
+          screen: {
+            height: 0,
+            width: 0,
+          },
+        },
+      } as ParticipantMouse);
     });
 
     test('should not call room.presence.update if isPrivate', () => {
@@ -648,7 +657,7 @@ describe('MousePointers on HTML', () => {
       presenceMouseComponent['goToPresenceCallback'] = callback;
       presenceMouseComponent['goToMouse']('unit-test-participant2-id');
 
-      expect(callback).toHaveBeenCalledWith({ x, y });
+      expect(callback).toHaveBeenCalledWith({ x, y, scaleX: 0, scaleY: 0 });
     });
   });
 

--- a/src/components/presence-mouse/types.ts
+++ b/src/components/presence-mouse/types.ts
@@ -10,6 +10,10 @@ export interface ParticipantMouse extends Participant {
 export interface Camera {
   x: number;
   y: number;
+  screen: {
+    width: number;
+    height: number;
+  };
   scale: number;
 }
 
@@ -21,9 +25,16 @@ export interface Transform {
   scale?: number;
 }
 
+export interface Position {
+  x: number;
+  y: number;
+  scaleX?: number;
+  scaleY?: number;
+}
+
 export interface PresenceMouseProps {
   callbacks: {
-    onGoToPresence?: (position: { x: number; y: number }) => void;
+    onGoToPresence?: (position: Position) => void;
   };
 }
 

--- a/src/components/presence-mouse/types.ts
+++ b/src/components/presence-mouse/types.ts
@@ -28,8 +28,8 @@ export interface Transform {
 export interface Position {
   x: number;
   y: number;
-  scaleX?: number;
-  scaleY?: number;
+  scaleX: number;
+  scaleY: number;
 }
 
 export interface PresenceMouseProps {

--- a/src/components/presence-mouse/types.ts
+++ b/src/components/presence-mouse/types.ts
@@ -4,6 +4,13 @@ export interface ParticipantMouse extends Participant {
   x: number;
   y: number;
   visible: boolean;
+  camera: Camera;
+}
+
+export interface Camera {
+  x: number;
+  y: number;
+  scale: number;
 }
 
 export interface Transform {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4487,7 +4487,7 @@ color-name@1.1.3:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-color-name@~1.1.4:
+color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -4782,6 +4782,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+cssfontparser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cssfontparser/-/cssfontparser-1.2.1.tgz#f4022fc8f9700c68029d542084afbaf425a3f3e3"
+  integrity sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==
 
 cssom@^0.5.0:
   version "0.5.0"
@@ -7198,6 +7203,14 @@ jest-browser-globals@^25.1.0-beta:
   resolved "https://registry.yarnpkg.com/jest-browser-globals/-/jest-browser-globals-25.1.0-beta.tgz#a687907cb2ce0009be91e0c6a71992a696023af1"
   integrity sha512-SlkemP7lm37mIWrFhIdQzenoivV9dmj5nSkDi5g3xeiBaulLiieFs5puaF9KMnzREIQRY/tfVgNQNr7uvGcLvg==
 
+jest-canvas-mock@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.5.2.tgz#7e21ebd75e05ab41c890497f6ba8a77f915d2ad6"
+  integrity sha512-vgnpPupjOL6+L5oJXzxTxFrlGEIbHdZqFU+LFNdtLxZ3lRDCl17FlTMM7IatoRQkrcyOTMlDinjUguqmQ6bR2A==
+  dependencies:
+    cssfontparser "^1.2.1"
+    moo-color "^1.0.2"
+
 jest-changed-files@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-29.7.0.tgz#1c06d07e77c78e1585d020424dedc10d6e17ac3a"
@@ -8597,6 +8610,13 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+moo-color@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/moo-color/-/moo-color-1.0.3.tgz#d56435f8359c8284d83ac58016df7427febece74"
+  integrity sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==
+  dependencies:
+    color-name "^1.1.4"
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Implementing a simple camera to see what the participants are seeing all the time. 

The coordinates that the `follow' functionality is based on have also been changed, before we centralized the mouse of the participant being followed, now we just centralize the view of the participant and calculate the scale that allows the mouse of the participant being followed to be seen at all times by the participant being followed. 

So the `onGoToPresence` callback has been changed to add the scale x and y factors. And also the `transform` method has been deprecated in the canvas mouse pointers, it's no longer necessary, we calculate all coordinates internally. 


- Change camera example: 

```ts
let cameraZoom = 0;
const cameraOffset = { x: 0, y: 0 };

const mousePointers = new MousePointers('mycanvas', {
  callbacks: {
    onGoToPresence: (coordinates) => {
      cameraZoom = coordinates.scaleX;
      cameraOffset.x = coordinates.x;
      cameraOffset.y = coordinates.y;
    },
  },
});
```

https://github.com/SuperViz/sdk/assets/49524331/67d2fbd4-b616-4006-9322-e6feb1a2765a


