### PR TITLE
feat: add support to multi channels

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "@superviz/socket-client": "1.2.2",
+    "@superviz/socket-client": "1.4.0",
     "ably": "^1.2.45",
     "bowser": "^2.11.0",
     "bowser-jr": "^1.0.6",

--- a/src/components/realtime/channel.test.ts
+++ b/src/components/realtime/channel.test.ts
@@ -1,0 +1,218 @@
+import { MOCK_OBSERVER_HELPER } from '../../../__mocks__/observer-helper.mock';
+import { MOCK_LOCAL_PARTICIPANT } from '../../../__mocks__/participants.mock';
+import { IOC } from '../../services/io';
+
+import { Channel } from './channel';
+import { RealtimeChannelState } from './types';
+
+jest.mock('lodash/throttle', () => jest.fn((fn) => fn));
+jest.useFakeTimers();
+
+describe('Realtime Channel', () => {
+  let ChannelInstance: Channel;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    console.error = jest.fn();
+    console.warn = jest.fn();
+    console.debug = jest.fn();
+
+    ChannelInstance = new Channel(
+      'channel',
+      new IOC(MOCK_LOCAL_PARTICIPANT),
+      MOCK_LOCAL_PARTICIPANT
+    );
+
+    ChannelInstance['state'] = RealtimeChannelState.CONNECTED;
+  });
+
+  describe('publish', () => {
+    test('should log an error when trying to publish an event before start', () => {
+      ChannelInstance['state'] = RealtimeChannelState.DISCONNECTED;
+
+      const spy = jest.spyOn(ChannelInstance['logger'], 'log' as any);
+      ChannelInstance.publish('test');
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    test('should publish an event', () => {
+      const spy = jest.spyOn(ChannelInstance['channel'], 'emit' as any);
+      ChannelInstance.publish('test');
+
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('subscribe', () => {
+    test('should subscribe to an event', () => {
+      ChannelInstance['observers']['test'] = MOCK_OBSERVER_HELPER;
+      const spy = jest.spyOn(ChannelInstance['observers']['test'], 'subscribe' as any);
+      ChannelInstance.subscribe('test', () => {});
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    test('should subscribe to an event when joined', () => {
+      ChannelInstance['state'] = RealtimeChannelState.DISCONNECTED;
+      ChannelInstance.subscribe('test', () => {});
+
+      expect(ChannelInstance['callbacksToSubscribeWhenJoined']).toHaveLength(1);
+    });
+  });
+
+  describe('unsubscribe', () => {
+    test('should unsubscribe from an event', () => {
+      ChannelInstance['observers']['test'] = MOCK_OBSERVER_HELPER;
+      const spy = jest.spyOn(ChannelInstance['observers']['test'], 'unsubscribe' as any);
+      ChannelInstance.unsubscribe('test', () => {});
+
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('subscribeToRealtimeEvents', () => {
+    test('should subscribe to all realtime events', () => {
+      const spy = jest.spyOn(ChannelInstance['channel'], 'on' as any);
+      ChannelInstance['subscribeToRealtimeEvents']();
+
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchHistory', () => {
+    test('should return null when the realtime is not started', async () => {
+      ChannelInstance['state'] = RealtimeChannelState.DISCONNECTED;
+      const h = await ChannelInstance.fetchHistory();
+
+      expect(h).toEqual(null);
+    });
+
+    test('should return null when the history is empty', async () => {
+      const spy = jest
+        .spyOn(ChannelInstance['channel'], 'history' as any)
+        .mockImplementationOnce((...args: unknown[]) => {
+          const next = args[0] as (data: any) => void;
+          next({ events: [] });
+        });
+
+      const h = await ChannelInstance.fetchHistory();
+
+      expect(spy).toHaveBeenCalled();
+      expect(h).toEqual(null);
+    });
+
+    test('should return the history', async () => {
+      const spy = jest
+        .spyOn(ChannelInstance['channel'], 'history' as any)
+        .mockImplementationOnce((...args: unknown[]) => {
+          const next = args[0] as (data: any) => void;
+          next({
+            events: [
+              {
+                timestamp: 1710336284652,
+                presence: { id: 'unit-test-presence-id', name: 'unit-test-presence-name' },
+                data: { name: 'unit-test-event-name', payload: 'unit-test-event-payload' },
+              },
+            ],
+          });
+        });
+
+      const h = await ChannelInstance.fetchHistory();
+      
+      expect(spy).toHaveBeenCalled();
+      expect(h).toEqual({
+        'unit-test-event-name': [
+          {
+            data: 'unit-test-event-payload',
+            name: 'unit-test-event-name',
+            participantId: 'unit-test-presence-id',
+            timestamp: 1710336284652,
+          },
+        ],
+      });
+    });
+
+    test('should return the history for a specific event', async () => {
+      const spy = jest
+        .spyOn(ChannelInstance['channel'], 'history' as any)
+        .mockImplementationOnce((...args: unknown[]) => {
+          const next = args[0] as (data: any) => void;
+          next({
+            events: [
+              {
+                timestamp: 1710336284652,
+                presence: { id: 'unit-test-presence-id', name: 'unit-test-presence-name' },
+                data: { name: 'unit-test-event-name', payload: 'unit-test-event-payload' },
+              },
+            ],
+          });
+        });
+
+      const h = await ChannelInstance.fetchHistory('unit-test-event-name');
+
+      expect(spy).toHaveBeenCalled();
+      expect(h).toEqual([
+        {
+          data: 'unit-test-event-payload',
+          name: 'unit-test-event-name',
+          participantId: 'unit-test-presence-id',
+          timestamp: 1710336284652,
+        },
+      ]);
+    });
+
+    test('should reject when the event is not found', async () => {
+      const spy = jest
+        .spyOn(ChannelInstance['channel'], 'history' as any)
+        .mockImplementationOnce((...args: unknown[]) => {
+          const next = args[0] as (data: any) => void;
+          next({
+            events: [
+              {
+                timestamp: 1710336284652,
+                presence: { id: 'unit-test-presence-id', name: 'unit-test-presence-name' },
+                data: { name: 'unit-test-event-name', payload: 'unit-test-event-payload' },
+              },
+            ],
+          });
+        });
+
+      const h = ChannelInstance.fetchHistory('unit-test-event-wrong-name');
+
+      await expect(h).rejects.toThrow('Event unit-test-event-wrong-name not found in the history');
+    });
+  });
+
+  describe('disconnect', () => {
+    test('should disconnect from the channel', () => {
+      const spy = jest.spyOn(ChannelInstance['channel'], 'disconnect' as any);
+
+      expect(ChannelInstance['state']).toEqual(RealtimeChannelState.CONNECTED);
+
+      ChannelInstance.disconnect();
+
+      expect(spy).toHaveBeenCalled();
+      expect(ChannelInstance['state']).toEqual(RealtimeChannelState.DISCONNECTED);
+    });
+
+    test('should not disconnect from the channel when already disconnected', () => {
+      const spy = jest.spyOn(ChannelInstance['channel'], 'disconnect' as any);
+      ChannelInstance['state'] = RealtimeChannelState.DISCONNECTED;
+
+      ChannelInstance.disconnect();
+      
+      expect(spy).not.toHaveBeenCalled();
+    });
+    
+    test('Should log an error if a disconnect attempt is made when the channel is already disconnected', () => {
+      const spy = jest.spyOn(ChannelInstance['logger'], 'log' as any);
+      ChannelInstance['state'] = RealtimeChannelState.DISCONNECTED;
+
+      ChannelInstance.disconnect();
+
+      expect(spy).toHaveBeenCalled();
+    })
+  });
+})

--- a/src/components/realtime/channel.ts
+++ b/src/components/realtime/channel.ts
@@ -1,0 +1,216 @@
+import * as Socket from '@superviz/socket-client';
+import throttle from 'lodash/throttle';
+
+import { ComponentLifeCycleEvent } from '../../common/types/events.types';
+import { Participant } from '../../common/types/participant.types';
+import { Logger, Observable, Observer } from "../../common/utils";
+import { IOC } from '../../services/io';
+
+import { RealtimeChannelEvent, RealtimeChannelState, RealtimeData, RealtimeMessage } from './types';
+
+export class Channel extends Observable {
+  private name: string;
+  private ioc: IOC;
+  private channel: Socket.Room;
+  protected logger: Logger;
+  private state: RealtimeChannelState = RealtimeChannelState.DISCONNECTED; 
+  private declare localParticipant: Participant;
+  private callbacksToSubscribeWhenJoined: Array<{
+    event: string;
+    callback: (data: unknown) => void;
+  }> = [];
+
+  constructor(name: string, ioc: IOC, localParticipant: Participant) {
+    super();
+
+    this.name = name;
+    this.ioc = ioc;
+    this.logger = new Logger('@superviz/sdk/realtime-channel');
+    this.channel = this.ioc.createRoom(`realtime:${this.name}`);
+    this.localParticipant = localParticipant;
+
+    this.subscribeToRealtimeEvents();
+    this.logger.log('started');
+  }
+
+  public async disconnect(): Promise<void> {
+    if (this.state === RealtimeChannelState.DISCONNECTED) {
+      this.logger.log('Realtime channel is already disconnected');
+      return
+    }
+
+    this.logger.log('destroyed')
+    this.changeState(RealtimeChannelState.DISCONNECTED);
+    this.channel.disconnect()
+  }
+
+  /**
+   * @function publish
+   * @description Publish an event
+   * @param type - event type
+   * @param data - event data
+   * @returns {void}
+   */
+  public publish = throttle((event: string, data?: unknown): void => {
+    if (Object.values(ComponentLifeCycleEvent).includes(event as ComponentLifeCycleEvent)) {
+      this.publishEventToClient(event, data);
+      return;
+    }
+
+    if (this.state !== RealtimeChannelState.CONNECTED) {
+      const message = `Realtime channel ${this.name} is not started yet. You can't publish event ${event} before start`;
+      this.logger.log(message);
+      console.warn(`[SuperViz] ${message}`);
+      return;
+    }
+
+    this.channel.emit(event, data)
+  }, 30);
+
+  /**
+   * @function subscribe
+   * @description subscribe to event
+   * @param event - event name
+   * @param callback - callback function
+   * @returns {void}
+   */
+  public subscribe = (event: string, callback: (data: unknown) => void): void => {
+    if (this.state !== RealtimeChannelState.CONNECTED) {
+      this.callbacksToSubscribeWhenJoined.push({ event, callback });
+      return;
+    }
+    if (!this.observers[event]) {
+      this.observers[event] = new Observer();
+    }
+
+    this.observers[event].subscribe(callback);
+  };
+
+  /**
+   * @function unsubscribe
+   * @description - unsubscribe from event
+   * @param event - event name
+   * @param callback - callback function
+   * @returns {void}
+   */
+  public unsubscribe = (event: string, callback?: (data: unknown) => void): void => {
+    if (!this.observers[event]) return;
+
+    this.observers[event].unsubscribe(callback);
+  };
+
+  /**
+   * @function changeState
+   * @description change realtime component state and publish state to client
+   * @param state
+   * @returns {void}
+   */
+  private changeState(state: RealtimeChannelState): void {
+    this.logger.log('realtime component @ changeState - state changed', state);
+    this.state = state;
+
+    this.publishEventToClient(RealtimeChannelEvent.REALTIME_CHANNEL_STATE_CHANGED, this.state);
+  }
+
+  private subscribeToRealtimeEvents(): void {
+    this.channel.presence.on(Socket.PresenceEvents.JOINED_ROOM, (event) => {
+      if (event.id !== this.localParticipant.id) return;
+
+      this.changeState(RealtimeChannelState.CONNECTED);
+
+      this.callbacksToSubscribeWhenJoined.forEach(({ event, callback }) => {
+        this.subscribe(event, callback);
+      });
+
+      this.logger.log('joined room');
+      // publishing again to make sure all clients know that we are connected
+      this.changeState(RealtimeChannelState.CONNECTED);
+    });
+
+    this.channel.on<RealtimeData>('message', (event) => {
+      this.logger.log('message received', event);
+      this.publishEventToClient(event.data.name, {
+        data: event.data.payload,
+        participantId: event.presence.id,
+        name: event.data.name,
+        timestamp: event.timestamp,
+      } as RealtimeMessage);
+    });
+  }
+
+  /**
+   * @function publishEventToClient
+   * @description - publish event to client
+   * @param event - event name
+   * @param data - data to publish
+   * @returns {void}
+   */
+  public publishEventToClient = (event: string, data?: unknown): void => {
+    this.logger.log('pubsub service @ publishEventToClient', { event, data });
+
+    if (!this.observers[event]) return;
+
+    this.observers[event].publish(data);
+  };
+
+
+  /**
+   * @function fetchHistory
+   * @description get realtime client data history
+   * @returns {RealtimeMessage | Record<string, RealtimeMessage>}
+   */
+  public fetchHistory = async (
+    eventName?: string,
+  ): Promise<RealtimeMessage[] | Record<string, RealtimeMessage[]> | null> => {
+    if (this.state !== RealtimeChannelState.CONNECTED) {
+      const message = `Realtime component is not started yet. You can't retrieve history before start`;
+
+      this.logger.log(message);
+      console.warn(`[SuperViz] ${message}`);
+      return null;
+    }
+
+    const history: RealtimeMessage[] | Record<string, RealtimeMessage[]> = await new Promise(
+      (resolve, reject) => {
+        const next = (data: Socket.RoomHistory) => {
+          if (!data.events?.length) {
+            resolve(null);
+          }
+
+          const groupMessages = data.events.reduce(
+            (group: Record<string, RealtimeMessage[]>, event: Socket.SocketEvent<RealtimeData>) => {
+              if (!group[event.data.name]) {
+                // eslint-disable-next-line no-param-reassign
+                group[event.data.name] = [];
+              }
+
+              group[event.data.name].push({
+                data: event.data.payload,
+                name: event.data.name,
+                participantId: event.presence.id,
+                timestamp: event.timestamp,
+              });
+
+              return group;
+            },
+            {},
+          );
+
+          if (eventName && !groupMessages[eventName]) {
+            reject(new Error(`Event ${eventName} not found in the history`));
+          }
+
+          if (eventName) {
+            resolve(groupMessages[eventName]);
+          }
+
+          resolve(groupMessages);
+        };
+
+        this.channel.history(next);
+      },
+    );
+
+    return history;
+  };
+}

--- a/src/components/realtime/channel.ts
+++ b/src/components/realtime/channel.ts
@@ -3,7 +3,7 @@ import throttle from 'lodash/throttle';
 
 import { ComponentLifeCycleEvent } from '../../common/types/events.types';
 import { Participant } from '../../common/types/participant.types';
-import { Logger, Observable, Observer } from "../../common/utils";
+import { Logger, Observable, Observer } from '../../common/utils';
 import { IOC } from '../../services/io';
 
 import { RealtimeChannelEvent, RealtimeChannelState, RealtimeData, RealtimeMessage } from './types';
@@ -13,7 +13,7 @@ export class Channel extends Observable {
   private ioc: IOC;
   private channel: Socket.Room;
   protected logger: Logger;
-  private state: RealtimeChannelState = RealtimeChannelState.DISCONNECTED; 
+  private state: RealtimeChannelState = RealtimeChannelState.DISCONNECTED;
   private declare localParticipant: Participant;
   private callbacksToSubscribeWhenJoined: Array<{
     event: string;
@@ -36,12 +36,12 @@ export class Channel extends Observable {
   public async disconnect(): Promise<void> {
     if (this.state === RealtimeChannelState.DISCONNECTED) {
       this.logger.log('Realtime channel is already disconnected');
-      return
+      return;
     }
 
-    this.logger.log('destroyed')
+    this.logger.log('destroyed');
     this.changeState(RealtimeChannelState.DISCONNECTED);
-    this.channel.disconnect()
+    this.channel.disconnect();
   }
 
   /**
@@ -64,7 +64,7 @@ export class Channel extends Observable {
       return;
     }
 
-    this.channel.emit('message', { name: event, payload: data });
+    this.channel.emit(`message:${this.name}`, { name: event, payload: data });
   }, 30);
 
   /**
@@ -128,7 +128,7 @@ export class Channel extends Observable {
       this.changeState(RealtimeChannelState.CONNECTED);
     });
 
-    this.channel.on<RealtimeData>('message', (event) => {
+    this.channel.on<RealtimeData>(`message:${this.name}`, (event) => {
       this.logger.log('message received', event);
       this.publishEventToClient(event.data.name, {
         data: event.data.payload,
@@ -153,7 +153,6 @@ export class Channel extends Observable {
 
     this.observers[event].publish(data);
   };
-
 
   /**
    * @function fetchHistory

--- a/src/components/realtime/channel.ts
+++ b/src/components/realtime/channel.ts
@@ -64,7 +64,7 @@ export class Channel extends Observable {
       return;
     }
 
-    this.channel.emit(event, data)
+    this.channel.emit('message', { name: event, payload: data });
   }, 30);
 
   /**
@@ -79,6 +79,7 @@ export class Channel extends Observable {
       this.callbacksToSubscribeWhenJoined.push({ event, callback });
       return;
     }
+
     if (!this.observers[event]) {
       this.observers[event] = new Observer();
     }

--- a/src/components/realtime/index.test.ts
+++ b/src/components/realtime/index.test.ts
@@ -46,199 +46,50 @@ describe('realtime component', () => {
   });
 
   describe('start', () => {
-    test('should subscribe to realtiem events', () => {
-      const spy = jest.spyOn(RealtimeComponentInstance, 'subscribeToRealtimeEvents' as any);
+    test('should log started', () => {
+      const spy = jest.spyOn(RealtimeComponentInstance['logger'], 'log');
       RealtimeComponentInstance['start']();
+
+      expect(spy).toHaveBeenCalledWith('started');
+      expect(RealtimeComponentInstance['state']).toBe(RealtimeComponentState.STARTED);
+    });
+  });
+
+  describe('connect', () => {
+    test('should log an error when trying to create a channel before start', () => {
+      RealtimeComponentInstance['state'] = RealtimeComponentState.STOPPED;
+
+      const spy = jest.spyOn(RealtimeComponentInstance['logger'], 'log');
+      RealtimeComponentInstance.connect('test');
 
       expect(spy).toHaveBeenCalled();
     });
 
-    test('should subscribe to callbacks when joined', () => {
-      const spy = jest.spyOn(RealtimeComponentInstance['room'], 'on' as any);
-      RealtimeComponentInstance['start']();
+    test('should create a new channel', () => {
+      const channel = RealtimeComponentInstance.connect('test');
 
-      expect(spy).toHaveBeenCalled();
+      expect(channel).toBeDefined();
+      expect(RealtimeComponentInstance['channels']).toHaveLength(1);
+      expect(RealtimeComponentInstance['channels'][0]).toBe(channel);
     });
   });
 
   describe('destroy', () => {
-    test('should disconnect from the room', () => {
-      const spy = jest.spyOn(RealtimeComponentInstance['room'], 'disconnect' as any);
+    test('should disconnect from the channels', () => {
+      const channel = RealtimeComponentInstance.connect('test');
+
+      const spy = jest.spyOn(RealtimeComponentInstance, 'disconnectToAllChannels' as any);
+      const spy2 = jest.spyOn(channel, 'disconnect' as any);
       RealtimeComponentInstance['destroy']();
 
       expect(spy).toHaveBeenCalled();
+      expect(spy2).toHaveBeenCalled();
     });
 
     test('should change state to stopped', () => {
       RealtimeComponentInstance['destroy']();
 
       expect(RealtimeComponentInstance['state']).toBe('STOPPED');
-    });
-  });
-
-  describe('publish', () => {
-    test('should log an error when trying to publish an event before start', () => {
-      RealtimeComponentInstance['state'] = RealtimeComponentState.STOPPED;
-
-      const spy = jest.spyOn(RealtimeComponentInstance['logger'], 'log' as any);
-      RealtimeComponentInstance.publish('test');
-
-      expect(spy).toHaveBeenCalled();
-    });
-
-    test('should publish an event', () => {
-      const spy = jest.spyOn(RealtimeComponentInstance['room'], 'emit' as any);
-      RealtimeComponentInstance['start']();
-      RealtimeComponentInstance.publish('test');
-
-      expect(spy).toHaveBeenCalled();
-    });
-  });
-
-  describe('subscribe', () => {
-    test('should subscribe to an event', () => {
-      RealtimeComponentInstance['observers']['test'] = MOCK_OBSERVER_HELPER;
-      const spy = jest.spyOn(RealtimeComponentInstance['observers']['test'], 'subscribe' as any);
-      RealtimeComponentInstance['start']();
-      RealtimeComponentInstance.subscribe('test', () => {});
-
-      expect(spy).toHaveBeenCalled();
-    });
-
-    test('should subscribe to an event when joined', () => {
-      RealtimeComponentInstance['state'] = RealtimeComponentState.STOPPED;
-      RealtimeComponentInstance.subscribe('test', () => {});
-
-      expect(RealtimeComponentInstance['callbacksToSubscribeWhenJoined']).toHaveLength(1);
-    });
-  });
-
-  describe('unsubscribe', () => {
-    test('should unsubscribe from an event', () => {
-      RealtimeComponentInstance['observers']['test'] = MOCK_OBSERVER_HELPER;
-      const spy = jest.spyOn(RealtimeComponentInstance['observers']['test'], 'unsubscribe' as any);
-      RealtimeComponentInstance['start']();
-      RealtimeComponentInstance.unsubscribe('test', () => {});
-
-      expect(spy).toHaveBeenCalled();
-    });
-  });
-
-  describe('subscribeToRealtimeEvents', () => {
-    test('should subscribe to all realtime events', () => {
-      const spy = jest.spyOn(RealtimeComponentInstance['room'], 'on' as any);
-      RealtimeComponentInstance['start']();
-      RealtimeComponentInstance['subscribeToRealtimeEvents']();
-
-      expect(spy).toHaveBeenCalled();
-    });
-  });
-
-  describe('fetchHistory', () => {
-    test('should return null when the realtime is not started', async () => {
-      RealtimeComponentInstance['state'] = RealtimeComponentState.STOPPED;
-      const h = await RealtimeComponentInstance.fetchHistory();
-
-      expect(h).toEqual(null);
-    });
-
-    test('should return null when the history is empty', async () => {
-      const spy = jest
-        .spyOn(RealtimeComponentInstance['room'], 'history' as any)
-        .mockImplementationOnce((...args: unknown[]) => {
-          const next = args[0] as (data: any) => void;
-          next({ events: [] });
-        });
-
-      RealtimeComponentInstance['start']();
-      const h = await RealtimeComponentInstance.fetchHistory();
-
-      expect(spy).toHaveBeenCalled();
-      expect(h).toEqual(null);
-    });
-
-    test('should return the history', async () => {
-      const spy = jest
-        .spyOn(RealtimeComponentInstance['room'], 'history' as any)
-        .mockImplementationOnce((...args: unknown[]) => {
-          const next = args[0] as (data: any) => void;
-          next({
-            events: [
-              {
-                timestamp: 1710336284652,
-                presence: { id: 'unit-test-presence-id', name: 'unit-test-presence-name' },
-                data: { name: 'unit-test-event-name', payload: 'unit-test-event-payload' },
-              },
-            ],
-          });
-        });
-
-      RealtimeComponentInstance['start']();
-      const h = await RealtimeComponentInstance.fetchHistory();
-
-      expect(spy).toHaveBeenCalled();
-      expect(h).toEqual({
-        'unit-test-event-name': [
-          {
-            data: 'unit-test-event-payload',
-            name: 'unit-test-event-name',
-            participantId: 'unit-test-presence-id',
-            timestamp: 1710336284652,
-          },
-        ],
-      });
-    });
-
-    test('should return the history for a specific event', async () => {
-      const spy = jest
-        .spyOn(RealtimeComponentInstance['room'], 'history' as any)
-        .mockImplementationOnce((...args: unknown[]) => {
-          const next = args[0] as (data: any) => void;
-          next({
-            events: [
-              {
-                timestamp: 1710336284652,
-                presence: { id: 'unit-test-presence-id', name: 'unit-test-presence-name' },
-                data: { name: 'unit-test-event-name', payload: 'unit-test-event-payload' },
-              },
-            ],
-          });
-        });
-
-      RealtimeComponentInstance['start']();
-      const h = await RealtimeComponentInstance.fetchHistory('unit-test-event-name');
-
-      expect(spy).toHaveBeenCalled();
-      expect(h).toEqual([
-        {
-          data: 'unit-test-event-payload',
-          name: 'unit-test-event-name',
-          participantId: 'unit-test-presence-id',
-          timestamp: 1710336284652,
-        },
-      ]);
-    });
-
-    test('should reject when the event is not found', async () => {
-      const spy = jest
-        .spyOn(RealtimeComponentInstance['room'], 'history' as any)
-        .mockImplementationOnce((...args: unknown[]) => {
-          const next = args[0] as (data: any) => void;
-          next({
-            events: [
-              {
-                timestamp: 1710336284652,
-                presence: { id: 'unit-test-presence-id', name: 'unit-test-presence-name' },
-                data: { name: 'unit-test-event-name', payload: 'unit-test-event-payload' },
-              },
-            ],
-          });
-        });
-
-      RealtimeComponentInstance['start']();
-      const h = RealtimeComponentInstance.fetchHistory('unit-test-event-wrong-name');
-
-      await expect(h).rejects.toThrow('Event unit-test-event-wrong-name not found in the history');
     });
   });
 });

--- a/src/components/realtime/index.ts
+++ b/src/components/realtime/index.ts
@@ -1,30 +1,18 @@
-import * as Socket from '@superviz/socket-client';
-import throttle from 'lodash/throttle';
-
-import { ComponentLifeCycleEvent } from '../../common/types/events.types';
+import { Participant } from '../../common/types/participant.types';
 import { StoreType } from '../../common/types/stores.types';
-import { Logger, Observer } from '../../common/utils';
-import { BaseComponent } from '../base';
+import { Logger } from '../../common/utils';
+import { BaseComponent } from "../base";
 import { ComponentNames } from '../types';
-import { Participant } from '../who-is-online/types';
 
-import {
-  RealtimeComponentEvent,
-  RealtimeComponentState,
-  RealtimeData,
-  RealtimeMessage,
-} from './types';
+import { Channel } from './channel';
+import { RealtimeComponentEvent, RealtimeComponentState } from './types';
 
 export class Realtime extends BaseComponent {
-  private callbacksToSubscribeWhenJoined: Array<{
-    event: string;
-    callback: (data: unknown) => void;
-  }> = [];
-
   protected logger: Logger;
   public name: ComponentNames;
-  private state: RealtimeComponentState = RealtimeComponentState.STOPPED;
   private declare localParticipant: Participant;
+  private state: RealtimeComponentState = RealtimeComponentState.STOPPED;
+  private channels: Array<Channel> = [];
 
   constructor() {
     super();
@@ -35,171 +23,41 @@ export class Realtime extends BaseComponent {
     localParticipant.subscribe();
   }
 
-  protected destroy(): void {
-    this.logger.log('destroyed');
-    this.changeState(RealtimeComponentState.STOPPED);
-    this.room.disconnect();
+  public connect(name: string): any {
+    if (this.state !== RealtimeComponentState.STARTED) {
+      this.logger.log('Realtime component is not started yet. You can\'t create a channel before start');
+      return;
+    }
+
+    const channel = new Channel(
+      name,
+      this.ioc,
+      this.localParticipant
+    );
+
+    this.channels.push(channel);
+
+    return channel;
   }
 
   protected start(): void {
     this.logger.log('started');
+    this.changeState(RealtimeComponentState.STARTED);
+  }
 
-    this.subscribeToRealtimeEvents();
+  protected destroy(): void {
+    this.logger.log('destroyed')
+    this.changeState(RealtimeComponentState.STOPPED);
+    this.disconnectToAllChannels();
   }
 
   /**
-   * @function publish
-   * @description Publish an event
-   * @param type - event type
-   * @param data - event data
+   * @function disconnectToAllChannels
+   * @description - disconnect to all channels
    * @returns {void}
    */
-  public publish = throttle((event: string, data?: unknown): void => {
-    if (Object.values(ComponentLifeCycleEvent).includes(event as ComponentLifeCycleEvent)) {
-      this.publishEventToClient(event, data);
-      return;
-    }
-
-    if (this.state !== RealtimeComponentState.STARTED) {
-      const message = `Realtime component is not started yet. You can't publish event ${event} before start`;
-      this.logger.log(message);
-      console.warn(`[SuperViz] ${message}`);
-      return;
-    }
-
-    this.room.emit('message', { name: event, payload: data });
-  }, 30);
-
-  /**
-   * @function subscribe
-   * @description subscribe to event
-   * @param event - event name
-   * @param callback - callback function
-   * @returns {void}
-   */
-  public subscribe = (event: string, callback: (data: unknown) => void): void => {
-    if (this.state !== RealtimeComponentState.STARTED) {
-      this.callbacksToSubscribeWhenJoined.push({ event, callback });
-      return;
-    }
-
-    if (!this.observers[event]) {
-      this.observers[event] = new Observer();
-    }
-
-    this.observers[event].subscribe(callback);
-  };
-
-  /**
-   * @function unsubscribe
-   * @description - unsubscribe from event
-   * @param event - event name
-   * @param callback - callback function
-   * @returns {void}
-   */
-  public unsubscribe = (event: string, callback?: (data: unknown) => void): void => {
-    if (!this.observers[event]) return;
-
-    this.observers[event].unsubscribe(callback);
-  };
-
-  /**
-   * @function fetchHistory
-   * @description get realtime client data history
-   * @returns {RealtimeMessage | Record<string, RealtimeMessage>}
-   */
-  public fetchHistory = async (
-    eventName?: string,
-  ): Promise<RealtimeMessage[] | Record<string, RealtimeMessage[]> | null> => {
-    if (this.state !== RealtimeComponentState.STARTED) {
-      const message = `Realtime component is not started yet. You can't retrieve history before start`;
-
-      this.logger.log(message);
-      console.warn(`[SuperViz] ${message}`);
-      return null;
-    }
-
-    const history: RealtimeMessage[] | Record<string, RealtimeMessage[]> = await new Promise(
-      (resolve, reject) => {
-        const next = (data: Socket.RoomHistory) => {
-          if (!data.events?.length) {
-            resolve(null);
-          }
-
-          const groupMessages = data.events.reduce(
-            (group: Record<string, RealtimeMessage[]>, event: Socket.SocketEvent<RealtimeData>) => {
-              if (!group[event.data.name]) {
-                // eslint-disable-next-line no-param-reassign
-                group[event.data.name] = [];
-              }
-
-              group[event.data.name].push({
-                data: event.data.payload,
-                name: event.data.name,
-                participantId: event.presence.id,
-                timestamp: event.timestamp,
-              });
-
-              return group;
-            },
-            {},
-          );
-
-          if (eventName && !groupMessages[eventName]) {
-            reject(new Error(`Event ${eventName} not found in the history`));
-          }
-
-          if (eventName) {
-            resolve(groupMessages[eventName]);
-          }
-
-          resolve(groupMessages);
-        };
-
-        this.room.history(next);
-      },
-    );
-
-    return history;
-  };
-
-  /**
-   * @function changeState
-   * @description change realtime component state and publish state to client
-   * @param state
-   * @returns {void}
-   */
-  private changeState(state: RealtimeComponentState): void {
-    this.logger.log('realtime component @ changeState - state changed', state);
-    this.state = state;
-
-    this.publishEventToClient(RealtimeComponentEvent.REALTIME_STATE_CHANGED, this.state);
-  }
-
-  private subscribeToRealtimeEvents(): void {
-    this.room.presence.on(Socket.PresenceEvents.JOINED_ROOM, (event) => {
-      if (event.id !== this.localParticipant.id) return;
-
-      this.changeState(RealtimeComponentState.STARTED);
-
-      this.callbacksToSubscribeWhenJoined.forEach(({ event, callback }) => {
-        this.subscribe(event, callback);
-      });
-
-      this.logger.log('joined room');
-      // publishing again to make sure all clients know that we are connected
-      this.changeState(RealtimeComponentState.STARTED);
-    });
-
-    this.room.on<RealtimeData>('message', (event) => {
-      this.logger.log('message received', event);
-      this.publishEventToClient(event.data.name, {
-        data: event.data.payload,
-        participantId: event.presence.id,
-        name: event.data.name,
-        timestamp: event.timestamp,
-      } as RealtimeMessage);
-    });
+  private disconnectToAllChannels(): void {
+    this.channels.forEach((channel) => channel.disconnect());
   }
 
   /**
@@ -216,4 +74,17 @@ export class Realtime extends BaseComponent {
 
     this.observers[event].publish(data);
   };
+
+  /**
+   * @function changeState
+   * @description change realtime component state and publish state to client
+   * @param state
+   * @returns {void}
+   */
+  private changeState(state: RealtimeComponentState): void {
+    this.logger.log('realtime component @ changeState - state changed', state);
+    this.state = state;
+
+    this.publishEventToClient(RealtimeComponentEvent.REALTIME_STATE_CHANGED, this.state);
+  }
 }

--- a/src/components/realtime/index.ts
+++ b/src/components/realtime/index.ts
@@ -1,7 +1,7 @@
 import { Participant } from '../../common/types/participant.types';
 import { StoreType } from '../../common/types/stores.types';
 import { Logger } from '../../common/utils';
-import { BaseComponent } from "../base";
+import { BaseComponent } from '../base';
 import { ComponentNames } from '../types';
 
 import { Channel } from './channel';
@@ -25,15 +25,13 @@ export class Realtime extends BaseComponent {
 
   public connect(name: string): any {
     if (this.state !== RealtimeComponentState.STARTED) {
-      this.logger.log('Realtime component is not started yet. You can\'t create a channel before start');
+      this.logger.log(
+        "Realtime component is not started yet. You can't create a channel before start",
+      );
       return;
     }
 
-    const channel = new Channel(
-      name,
-      this.ioc,
-      this.localParticipant
-    );
+    const channel = new Channel(name, this.ioc, this.localParticipant);
 
     this.channels.push(channel);
 
@@ -46,7 +44,7 @@ export class Realtime extends BaseComponent {
   }
 
   protected destroy(): void {
-    this.logger.log('destroyed')
+    this.logger.log('destroyed');
     this.changeState(RealtimeComponentState.STOPPED);
     this.disconnectToAllChannels();
   }

--- a/src/components/realtime/types.ts
+++ b/src/components/realtime/types.ts
@@ -3,8 +3,18 @@ export enum RealtimeComponentState {
   STOPPED = 'STOPPED',
 }
 
+export enum RealtimeChannelState {
+  DISCONNECTED = 'DISCONNECTED',
+  CONNECTED = 'CONNECTED',
+  CONNECTING = 'CONNECTING',
+}
+
 export enum RealtimeComponentEvent {
   REALTIME_STATE_CHANGED = 'realtime-component.state-changed',
+}
+
+export enum RealtimeChannelEvent {
+  REALTIME_CHANNEL_STATE_CHANGED = 'realtime-channel.state-changed',
 }
 
 export type RealtimeData = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2481,10 +2481,10 @@
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
   integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
 
-"@superviz/socket-client@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@superviz/socket-client/-/socket-client-1.2.2.tgz#6f228e84588051ca092e827c172af6c8f18182f5"
-  integrity sha512-JDvKBtyamCe00Tf0KM5Uaac73LVafcLKlByPxXBc5wTmcEo/cuLeaQ4sbpQzUUwJaS2ptnbvZMmYkhL3SnW1AQ==
+"@superviz/socket-client@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@superviz/socket-client/-/socket-client-1.4.0.tgz#374326131dd4a89f2d8f71e8be1305ed55311921"
+  integrity sha512-Ue66/5dxhGaPxqiFE3KWjusfp2FCBmT8vPJfq8FMD/ZCR6ac/tqnKqLrMtpz3oA6/51CQW9tfoSuqaXC+hrKWw==
   dependencies:
     "@reactivex/rxjs" "^6.6.7"
     debug "^4.3.4"


### PR DESCRIPTION
Implementing Multi-Channel Support
Previously, only supported a single channel. Now, I'm introducing multi-channel support, allowing clients to define their own channels.
Now, I've implemented multi-channel support, enabling clients to define their own channels. To achieve this, I've created a new class capable of distributing methods for `subscribe`, `unsubscribe`, `publish`, and `disconnect`.

### Before
Previously, when connecting to Realtime, we would receive one channel along with its respective handling methods.

```ts
const realtime = Realtime()

realtime.subscribe()
realtime.publish()
realtime.fetchHistory()
```

### After
Now, with the introduction of multi-channel support, we instantiate the Realtime class and then connect to whichever channels are desired. For example:

```ts
const realtime = Realtime()

const channel1 = realtime.connect('channel1')
const channel2 = realtime.connect('channel2')
const channel3 = realtime.connect('channel3')
```

Subsequently, for each respective channel created, we receive the corresponding set of handling methods.

```ts
channel1.subscribe()
channel1.publish()
channel1.fetchHistory()
channel1.disconnect()

channel2.subscribe()
channel2.publish()
channel2.fetchHistory()
channel2.disconnect()

channel3.subscribe()
channel3.publish()
channel3.fetchHistory()
channel3.disconnect()
```