### PR TITLE
feat: improve type and autocompletion in stores

### DIFF
--- a/src/common/types/stores.types.ts
+++ b/src/common/types/stores.types.ts
@@ -8,14 +8,19 @@ export enum StoreType {
   WHO_IS_ONLINE = 'who-is-online-store',
 }
 
-type StoreApi<T extends (...args: any[]) => any> = {
+type Subject<T extends (...args: any[]) => any, K extends keyof ReturnType<T>> = ReturnType<T>[K]
+
+type StoreApiWithoutDestroy<T extends (...args: any[]) => any> = {
   [K in keyof ReturnType<T>]: {
-    subscribe(callback?: (value: keyof T) => void): void;
-    subject: PublicSubject<keyof T>;
-    publish<T>(value: T): void;
-    value: any;
+    subscribe(callback?: (value: Subject<T, K>['value']) => void): void;
+    subject: Subject<T, K>;
+    publish(value: Subject<T, K>['value']): void;
+    value: Subject<T, K>['value'];
   };
-};
+}
+
+type StoreApi<T extends (...args: any[]) => any> = Omit<StoreApiWithoutDestroy<T>, 'destroy'> & { destroy(): void };
+
 
 // When creating new Stores, expand the ternary with the new Store. For example:
 // ...T extends StoreType.GLOBAL ? StoreApi<typeof useGlobalStore> : T extends StoreType.WHO_IS_ONLINE ? StoreApi<typeof useWhoIsOnlineStore> : never;

--- a/src/common/utils/use-store.ts
+++ b/src/common/utils/use-store.ts
@@ -38,21 +38,20 @@ function subscribeTo<T>(
  * @description Returns a proxy of the global store data and a subscribe function to be used in the components
  */
 export function useStore<T extends StoreType>(name: T): Store<T> {
-  // @TODO - Improve types to get better sugestions when writing code
   const storeData = stores[name as StoreType]();
   const bindedSubscribeTo = subscribeTo.bind(this);
 
   const proxy = new Proxy(storeData, {
-    get(store: Store<T>, valueName: string) {
+    get(store, valueName: string) {
       return {
-        subscribe<K extends Store<T>>(callback?: (value: K) => void) {
+        subscribe(callback?) {
           bindedSubscribeTo(valueName, store[valueName], callback);
         },
-        subject: store[valueName] as typeof storeData,
+        subject: store[valueName],
         get value() {
           return this.subject.value;
         },
-        publish(newValue: keyof Store<T>) {
+        publish(newValue) {
           this.subject.value = newValue;
         },
       };

--- a/src/common/utils/use-store.ts
+++ b/src/common/utils/use-store.ts
@@ -43,6 +43,8 @@ export function useStore<T extends StoreType>(name: T): Store<T> {
 
   const proxy = new Proxy(storeData, {
     get(store, valueName: string) {
+      if (valueName === 'destroy') return store.destroy;
+      
       return {
         subscribe(callback?) {
           bindedSubscribeTo(valueName, store[valueName], callback);

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -11,6 +11,7 @@ import { AblyRealtimeService } from '../../services/realtime';
 import { ComponentNames } from '../types';
 
 import { DefaultAttachComponentOptions } from './types';
+import { useGlobalStore } from '../../services/stores';
 
 export abstract class BaseComponent extends Observable {
   public abstract name: ComponentNames;

--- a/src/components/comments/index.ts
+++ b/src/components/comments/index.ts
@@ -61,7 +61,7 @@ export class Comments extends BaseComponent {
     const { group, localParticipant } = this.useStore(StoreType.GLOBAL);
     group.subscribe();
 
-    localParticipant.subscribe((participant: Participant) => {
+    localParticipant.subscribe((participant) => {
       this.localParticipantId = participant.id;
     });
   }

--- a/src/components/form-elements/index.test.ts
+++ b/src/components/form-elements/index.test.ts
@@ -907,7 +907,7 @@ describe('form elements', () => {
       instance['publishTypedEvent']({ presence, data });
 
       expect(instance['publish']).toHaveBeenCalledWith(
-        `${FieldEvents.KEYBOARD_INTERACTION}-${fieldId}`,
+        FieldEvents.KEYBOARD_INTERACTION,
         {
           fieldId,
           userId: '123',

--- a/src/components/form-elements/index.ts
+++ b/src/components/form-elements/index.ts
@@ -605,7 +605,7 @@ export class FormElements extends BaseComponent {
   }: SocketEvent<InputPayload>) => {
     if (presence.id === this.localParticipant.id) return;
 
-    this.publish(`${FieldEvents.INPUT}-${fieldId}`, {
+    this.publish(FieldEvents.INPUT, {
       value,
       fieldId,
       attribute,
@@ -627,7 +627,7 @@ export class FormElements extends BaseComponent {
   }: SocketEvent<FocusPayload>) => {
     if (presence.id === this.localParticipant.id) return;
 
-    this.publish(`${FieldEvents.KEYBOARD_INTERACTION}-${fieldId}`, {
+    this.publish(FieldEvents.KEYBOARD_INTERACTION, {
       fieldId,
       userId: presence.id,
       userName: presence.name,

--- a/src/components/who-is-online/index.test.ts
+++ b/src/components/who-is-online/index.test.ts
@@ -278,7 +278,7 @@ describe('Who Is Online', () => {
         name: MOCK_ABLY_PARTICIPANT_DATA_2.name,
       };
       const { following } = whoIsOnlineComponent['useStore'](StoreType.WHO_IS_ONLINE);
-      following.publish<Following>(followingData);
+      following.publish(followingData);
 
       whoIsOnlineComponent['setFollow'](MOCK_ABLY_PARTICIPANT);
 
@@ -294,7 +294,7 @@ describe('Who Is Online', () => {
       };
 
       const { following } = whoIsOnlineComponent['useStore'](StoreType.WHO_IS_ONLINE);
-      following.publish<Following>(followingData);
+      following.publish(followingData);
 
       whoIsOnlineComponent['setFollow']({
         ...MOCK_ABLY_PARTICIPANT,
@@ -330,7 +330,7 @@ describe('Who Is Online', () => {
   describe('stopFollowing', () => {
     test('should do nothing if participant leaving is not being followed', () => {
       const { following } = whoIsOnlineComponent['useStore'](StoreType.WHO_IS_ONLINE);
-      following.publish<Following>({
+      following.publish({
         color: MOCK_ABLY_PARTICIPANT_DATA_2.color,
         id: MOCK_ABLY_PARTICIPANT_DATA_2.id,
         name: MOCK_ABLY_PARTICIPANT_DATA_2.name,
@@ -339,12 +339,12 @@ describe('Who Is Online', () => {
       whoIsOnlineComponent['stopFollowing'](MOCK_ABLY_PARTICIPANT);
 
       expect(following.value).toBeDefined();
-      expect(following.value.id).toBe(MOCK_ABLY_PARTICIPANT_DATA_2.id);
+      expect(following.value!.id).toBe(MOCK_ABLY_PARTICIPANT_DATA_2.id);
     });
 
     test('should set following to undefined if following the participant who is leaving', () => {
       const { following } = whoIsOnlineComponent['useStore'](StoreType.WHO_IS_ONLINE);
-      following.publish<Following>({
+      following.publish({
         color: MOCK_ABLY_PARTICIPANT_DATA_1.color,
         id: MOCK_ABLY_PARTICIPANT_DATA_1.id,
         name: MOCK_ABLY_PARTICIPANT_DATA_1.name,
@@ -406,7 +406,7 @@ describe('Who Is Online', () => {
         name: MOCK_ABLY_PARTICIPANT_DATA_2.name,
       };
       const { following } = whoIsOnlineComponent['useStore'](StoreType.WHO_IS_ONLINE);
-      following.publish<Following>(followingData);
+      following.publish(followingData);
 
       whoIsOnlineComponent['followMousePointer']({
         detail: { id: 'unit-test-id' },
@@ -438,7 +438,7 @@ describe('Who Is Online', () => {
 
     test('should publish "stop following" event when stopFollowing is called', () => {
       const { following } = whoIsOnlineComponent['useStore'](StoreType.WHO_IS_ONLINE);
-      following.publish<Following>({
+      following.publish({
         color: MOCK_ABLY_PARTICIPANT_DATA_2.color,
         id: MOCK_ABLY_PARTICIPANT_DATA_2.id,
         name: MOCK_ABLY_PARTICIPANT_DATA_2.name,
@@ -481,7 +481,7 @@ describe('Who Is Online', () => {
         name: MOCK_ABLY_PARTICIPANT_DATA_2.name,
       };
 
-      following.publish<Following>(followingData);
+      following.publish(followingData);
 
       whoIsOnlineComponent['follow']({
         detail: { id: 'unit-test-id' },
@@ -546,6 +546,7 @@ describe('Who Is Online', () => {
         disableGoToParticipant: { value: false },
         disableGatherAll: { value: false },
         disablePrivateMode: { value: false },
+        destroy: jest.fn(),
       });
 
       expect(
@@ -565,6 +566,7 @@ describe('Who Is Online', () => {
         disableGoToParticipant: { value: false },
         disableGatherAll: { value: false },
         disablePrivateMode: { value: false },
+        destroy: jest.fn(),
       });
 
       expect(
@@ -584,6 +586,7 @@ describe('Who Is Online', () => {
         disableGatherAll: { value: true },
         disableFollowParticipant: { value: true },
         disableGoToParticipant: { value: true },
+        destroy: jest.fn(),
       });
 
       expect(
@@ -603,6 +606,7 @@ describe('Who Is Online', () => {
         disableGoToParticipant: { value: false },
         disableGatherAll: { value: false },
         disablePrivateMode: { value: false },
+        destroy: jest.fn(),
       });
 
       expect(
@@ -622,6 +626,7 @@ describe('Who Is Online', () => {
         disableGoToParticipant: { value: false },
         disableGatherAll: { value: false },
         disablePrivateMode: { value: false },
+        destroy: jest.fn(),
       });
 
       expect(
@@ -865,7 +870,7 @@ describe('Who Is Online', () => {
       ](StoreType.WHO_IS_ONLINE);
       disableGoToParticipant.publish(false);
       disableFollowParticipant.publish(false);
-      following.publish<Following>({ color: 'red', id: 'participant123', name: 'name' });
+      following.publish({ color: 'red', id: 'participant123', name: 'name' });
 
       const controls = whoIsOnlineComponent['getOtherParticipantsControls']('participant123');
 
@@ -1053,7 +1058,7 @@ describe('Who Is Online', () => {
 
       participants.publish(participantsList);
       extras.publish([participant5]);
-      following.publish<Following>({
+      following.publish({
         color: 'red',
         id: 'test id 5',
         name: 'participant 5',

--- a/src/components/who-is-online/index.ts
+++ b/src/components/who-is-online/index.ts
@@ -72,8 +72,8 @@ export class WhoIsOnline extends BaseComponent {
    */
   protected start(): void {
     const { localParticipant } = this.useStore(StoreType.GLOBAL);
-    localParticipant.subscribe((value: { id: string }) => {
-      this.localParticipantId = value.id;
+    localParticipant.subscribe((participant) => {
+      this.localParticipantId = participant.id;
     });
 
     this.subscribeToRealtimeEvents();
@@ -94,6 +94,9 @@ export class WhoIsOnline extends BaseComponent {
     this.removeListeners();
     this.element.remove();
     this.element = null;
+
+    const { destroy } = this.useStore(StoreType.WHO_IS_ONLINE);
+    destroy();
   }
 
   /**
@@ -623,24 +626,24 @@ export class WhoIsOnline extends BaseComponent {
   private updateParticipantsControls(participantId: string | undefined): void {
     const { participants } = this.useStore(StoreType.WHO_IS_ONLINE);
 
-    participants.publish(
-      participants.value.map((participant: Participant) => {
-        if (participantId && participant.id !== participantId) return participant;
+    const newParticipantsList = participants.value.map((participant: Participant) => {
+      if (participantId && participant.id !== participantId) return participant;
 
-        const { id } = participant;
-        const disableDropdown = this.shouldDisableDropdown({
-          activeComponents: participant.activeComponents,
-          participantId: id,
-        });
-        const presenceEnabled = !disableDropdown;
-        const controls = this.getControls({ participantId: id, presenceEnabled }) ?? [];
+      const { id } = participant;
+      const disableDropdown = this.shouldDisableDropdown({
+        activeComponents: participant.activeComponents,
+        participantId: id,
+      });
+      const presenceEnabled = !disableDropdown;
+      const controls = this.getControls({ participantId: id, presenceEnabled }) ?? [];
 
-        return {
-          ...participant,
-          controls,
-        };
-      }),
-    );
+      return {
+        ...participant,
+        controls,
+      };
+    })
+
+    participants.publish(newParticipantsList);
   }
 
   /**

--- a/src/services/stores/global/index.ts
+++ b/src/services/stores/global/index.ts
@@ -20,6 +20,8 @@ export class GlobalStore {
 
   public destroy() {
     this.localParticipant.destroy();
+    this.participants.destroy();
+    this.group.destroy();
     instance.value = null;
   }
 }

--- a/src/services/stores/who-is-online/index.ts
+++ b/src/services/stores/who-is-online/index.ts
@@ -14,14 +14,11 @@ export class WhoIsOnlineStore {
   public disablePrivateMode = subject<boolean>(false);
   public disableGatherAll = subject<boolean>(false);
   public disableFollowMe = subject<boolean>(false);
-
   public participants = subject<Participant[]>([]);
   public extras = subject<Participant[]>([]);
-
   public joinedPresence = subject<boolean | undefined>(undefined);
   public everyoneFollowsMe = subject<boolean>(false);
   public privateMode = subject<boolean>(false);
-
   public following = subject<Following | undefined>(undefined);
 
   constructor() {
@@ -33,7 +30,19 @@ export class WhoIsOnlineStore {
   }
 
   public destroy() {
-    this.disablePresenceControls.destroy();
+    this.disableGoToParticipant.destroy()
+    this.disablePresenceControls.destroy()
+    this.disableFollowParticipant.destroy()
+    this.disablePrivateMode.destroy()
+    this.disableGatherAll.destroy()
+    this.disableFollowMe.destroy()
+    this.participants.destroy()
+    this.extras.destroy()
+    this.joinedPresence.destroy()
+    this.everyoneFollowsMe.destroy()
+    this.privateMode.destroy()
+    this.following.destroy()
+
     instance.value = null;
   }
 }

--- a/src/web-components/comments/components/annotation-pin.ts
+++ b/src/web-components/comments/components/annotation-pin.ts
@@ -152,7 +152,7 @@ export class CommentsAnnotationPin extends WebComponentsBaseElement {
     if (this.type !== PinMode.ADD) return;
 
     const { localParticipant } = this.useStore(StoreType.GLOBAL);
-    localParticipant.subscribe((participant: Participant) => {
+    localParticipant.subscribe((participant) => {
       this.localAvatar = participant?.avatar?.imageUrl;
       this.localName = participant?.name;
     });

--- a/src/web-components/who-is-online/components/dropdown.test.ts
+++ b/src/web-components/who-is-online/components/dropdown.test.ts
@@ -148,7 +148,7 @@ describe('who-is-online-dropdown', () => {
   test('should render dropdown', () => {
     createEl({ position: 'bottom' });
     const { extras } = useStore(StoreType.WHO_IS_ONLINE);
-    extras.publish<Participant[]>(MOCK_PARTICIPANTS);
+    extras.publish(MOCK_PARTICIPANTS);
 
     const element = document.querySelector('superviz-who-is-online-dropdown');
 
@@ -158,7 +158,7 @@ describe('who-is-online-dropdown', () => {
   test('should open dropdown when click on it', async () => {
     createEl({ position: 'bottom' });
     const { extras } = useStore(StoreType.WHO_IS_ONLINE);
-    extras.publish<Participant[]>(MOCK_PARTICIPANTS);
+    extras.publish(MOCK_PARTICIPANTS);
 
     await sleep();
 
@@ -172,7 +172,7 @@ describe('who-is-online-dropdown', () => {
   test('should close dropdown when click on it', async () => {
     createEl({ position: 'bottom' });
     const { extras } = useStore(StoreType.WHO_IS_ONLINE);
-    extras.publish<Participant[]>(MOCK_PARTICIPANTS);
+    extras.publish(MOCK_PARTICIPANTS);
 
     await sleep();
     dropdownContent()?.click();
@@ -194,7 +194,7 @@ describe('who-is-online-dropdown', () => {
   test('should open another dropdown when click on participant', async () => {
     createEl({ position: 'bottom' });
     const { extras } = useStore(StoreType.WHO_IS_ONLINE);
-    extras.publish<Participant[]>(MOCK_PARTICIPANTS);
+    extras.publish(MOCK_PARTICIPANTS);
 
     await sleep();
 
@@ -217,7 +217,7 @@ describe('who-is-online-dropdown', () => {
   test('should listen click event when click out', async () => {
     createEl({ position: 'bottom' });
     const { extras } = useStore(StoreType.WHO_IS_ONLINE);
-    extras.publish<Participant[]>(MOCK_PARTICIPANTS);
+    extras.publish(MOCK_PARTICIPANTS);
 
     await sleep();
 
@@ -240,7 +240,7 @@ describe('who-is-online-dropdown', () => {
     createEl({ position: 'bottom' });
 
     const { extras } = useStore(StoreType.WHO_IS_ONLINE);
-    extras.publish<Participant[]>([MOCK_PARTICIPANTS[2]]);
+    extras.publish([MOCK_PARTICIPANTS[2]]);
     await sleep();
 
     const letter = element()?.shadowRoot?.querySelector('.who-is-online__participant__avatar');
@@ -283,7 +283,7 @@ describe('who-is-online-dropdown', () => {
   test('should render participants when there is participant', async () => {
     createEl({ position: 'bottom' });
     const { extras } = useStore(StoreType.WHO_IS_ONLINE);
-    extras.publish<Participant[]>([MOCK_PARTICIPANTS[0]]);
+    extras.publish([MOCK_PARTICIPANTS[0]]);
 
     await sleep();
 
@@ -295,7 +295,7 @@ describe('who-is-online-dropdown', () => {
 
     createEl({ position: 'bottom' });
     const { extras } = useStore(StoreType.WHO_IS_ONLINE);
-    extras.publish<Participant[]>([
+    extras.publish([
       {
         avatar: {
           imageUrl: '',
@@ -329,7 +329,7 @@ describe('who-is-online-dropdown', () => {
   test('should not change selected participant when click on it if disableDropdown is true', async () => {
     createEl({ position: 'bottom' });
     const { extras } = useStore(StoreType.WHO_IS_ONLINE);
-    extras.publish<Participant[]>([
+    extras.publish([
       {
         ...MOCK_PARTICIPANTS[0],
         disableDropdown: true,
@@ -353,7 +353,7 @@ describe('who-is-online-dropdown', () => {
     test('should call reposition methods if is open', () => {
       const el = createEl({ position: 'bottom' });
       const { extras } = useStore(StoreType.WHO_IS_ONLINE);
-      extras.publish<Participant[]>(MOCK_PARTICIPANTS);
+      extras.publish(MOCK_PARTICIPANTS);
 
       el['open'] = true;
 
@@ -369,7 +369,7 @@ describe('who-is-online-dropdown', () => {
     test('should do nothing if is not open', () => {
       const el = createEl({ position: 'bottom' });
       const { extras } = useStore(StoreType.WHO_IS_ONLINE);
-      extras.publish<Participant[]>(MOCK_PARTICIPANTS);
+      extras.publish(MOCK_PARTICIPANTS);
 
       el['open'] = false;
 
@@ -392,7 +392,7 @@ describe('who-is-online-dropdown', () => {
     test('should set bottom and top styles when dropdownVerticalMidpoint is greater than windowVerticalMidpoint', async () => {
       const el = createEl({ position: 'bottom' });
       const { extras } = useStore(StoreType.WHO_IS_ONLINE);
-      extras.publish<Participant[]>(MOCK_PARTICIPANTS);
+      extras.publish(MOCK_PARTICIPANTS);
 
       await sleep();
 
@@ -415,7 +415,7 @@ describe('who-is-online-dropdown', () => {
     test('should set top and bottom styles when dropdownVerticalMidpoint is less than windowVerticalMidpoint', async () => {
       const el = createEl({ position: 'bottom' });
       const { extras } = useStore(StoreType.WHO_IS_ONLINE);
-      extras.publish<Participant[]>(MOCK_PARTICIPANTS);
+      extras.publish(MOCK_PARTICIPANTS);
 
       await sleep();
 

--- a/src/web-components/who-is-online/who-is-online.test.ts
+++ b/src/web-components/who-is-online/who-is-online.test.ts
@@ -355,7 +355,7 @@ describe('Who Is Online', () => {
       element.addEventListener(RealtimeEvent.REALTIME_FOLLOW_PARTICIPANT, spy);
 
       const { following } = useStore(StoreType.WHO_IS_ONLINE);
-      following.publish<Following>({ color: 'red', id: '1', name: 'John' });
+      following.publish({ color: 'red', id: '1', name: 'John' });
       element['following'] = { participantId: 1, slotIndex: 1 };
       await sleep();
 

--- a/src/web-components/who-is-online/who-is-online.ts
+++ b/src/web-components/who-is-online/who-is-online.ts
@@ -52,11 +52,11 @@ export class WhoIsOnline extends WebComponentsBaseElement {
     const { participants, following, extras } = this.useStore(StoreType.WHO_IS_ONLINE);
     participants.subscribe();
     following.subscribe();
-    extras.subscribe((participants: Participant[]) => {
+    extras.subscribe((participants) => {
       this.amountOfExtras = participants.length;
     });
 
-    localParticipant.subscribe((value: Participant) => {
+    localParticipant.subscribe((value) => {
       const joinedPresence = value.activeComponents?.some((component) =>
         component.toLowerCase().includes('presence'),
       );
@@ -249,7 +249,7 @@ export class WhoIsOnline extends WebComponentsBaseElement {
     this.emitEvent(RealtimeEvent.REALTIME_GO_TO_PARTICIPANT, { id: participantId });
   }
 
-  private handleLocalFollow(participantId: string, source: string) {
+  private handleLocalFollow(participantId: string, source: 'participants' | 'extras') {
     const { following } = this.useStore(StoreType.WHO_IS_ONLINE);
     const participants = this.useStore(StoreType.WHO_IS_ONLINE)[source].value;
 
@@ -286,12 +286,12 @@ export class WhoIsOnline extends WebComponentsBaseElement {
     this.isPrivate = false;
   }
 
-  private handleFollow(participantId: string, source: string) {
+  private handleFollow(participantId: string, source: 'participants' | 'extras') {
     if (this.isPrivate) {
       this.cancelPrivate();
     }
 
-    const participants: Participant[] = this.useStore(StoreType.WHO_IS_ONLINE)[source].value;
+    const participants = this.useStore(StoreType.WHO_IS_ONLINE)[source].value;
 
     const {
       id,


### PR DESCRIPTION
- Improve types when getting data from stores

Before:
![image](https://github.com/SuperViz/sdk/assets/111044527/bcbcbcd0-ac27-4230-a3b0-6cb584426f56)

After:
![image](https://github.com/SuperViz/sdk/assets/111044527/f617f43a-03ff-46e1-9883-df6c3d68c985)

What was crucial to achieve this was the line `type Subject<T extends (...args: any[]) => any, K extends keyof ReturnType<T>> = ReturnType<T>[K]`. Basically, `ReturnType<T>` is a type with every possible item in the store, while `K` is the name of the item. Since they're all of the type `PublicSubject`, acessing the type of the value is just a matter of indexing with ['value'] at the end: `Subject['value']`. Good stuff.

- Make knowing the id of a field when using Form Elements no longer necessary to subscribe to the events of the field

Requiring the id to merely subscribe to an event of a field made subscribing ugly and complicated if the person decides to register a field later, so now only the event name is required, and the callback is called with the fieldId in it in case the user wants to filter something.