### PR TITLE
fix: ensure that video frame is destroyed

### DIFF
--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -8,10 +8,10 @@ import config from '../../services/config';
 import { EventBus } from '../../services/event-bus';
 import { IOC } from '../../services/io';
 import { AblyRealtimeService } from '../../services/realtime';
+import { useGlobalStore } from '../../services/stores';
 import { ComponentNames } from '../types';
 
 import { DefaultAttachComponentOptions } from './types';
-import { useGlobalStore } from '../../services/stores';
 
 export abstract class BaseComponent extends Observable {
   public abstract name: ComponentNames;

--- a/src/components/video/index.ts
+++ b/src/components/video/index.ts
@@ -175,8 +175,8 @@ export class VideoConference extends BaseComponent {
     this.unsubscribeFromRealtimeEvents();
     this.unsubscribeFromVideoEvents();
 
-    this.videoManager.leave();
-    this.connectionService.removeListeners();
+    this.videoManager?.leave();
+    this.connectionService?.removeListeners();
   }
 
   /**
@@ -253,6 +253,8 @@ export class VideoConference extends BaseComponent {
    * @returns {void}
    * */
   private unsubscribeFromVideoEvents = (): void => {
+    if (!this.videoManager) return;
+
     this.logger.log('video conference @ unsubscribe from video events');
 
     this.videoManager.meetingConnectionObserver.unsubscribe(
@@ -503,7 +505,15 @@ export class VideoConference extends BaseComponent {
   private onParticipantLeft = (_: Participant): void => {
     this.logger.log('video conference @ on participant left', this.localParticipant);
 
+    this.videoManager.leave();
+    this.connectionService.removeListeners();
+    this.publish(MeetingEvent.DESTROY);
     this.publish(MeetingEvent.MY_PARTICIPANT_LEFT, this.localParticipant);
+
+    this.unsubscribeFromVideoEvents();
+    this.videoManager = undefined;
+    this.connectionService = undefined;
+
     this.detach();
   };
 


### PR DESCRIPTION
Fixed a bug that didn't destroy the video frame when the participant leaves the meeting. 

**Explanation**: Sometimes the process to destroy the video took too long, it's cause the video services lost the frame reference, causing an error that made it impossible to get destroyed. 

**To solve**: We make sure that the first thing we do when the participant leaves the meeting room is to destroy the frame. This will prevent the error and ensure that the meeting overlay is destroyed.