### PR TITLE
fix: make features acessible to 3d without importing from sdk

### DIFF
--- a/src/common/types/stores.types.ts
+++ b/src/common/types/stores.types.ts
@@ -26,13 +26,18 @@ type StoreApi<T extends (...args: any[]) => any> = Omit<StoreApiWithoutDestroy<T
   destroy(): void;
 };
 
-export type Store<T> = T extends StoreType.GLOBAL
+type GlobalStore = StoreType.GLOBAL | `${StoreType.GLOBAL}`;
+type WhoIsOnlineStore = StoreType.WHO_IS_ONLINE | 'who-is-online-store';
+type VideoStore = StoreType.VIDEO | 'video-store';
+type Presence3DStore = StoreType.PRESENCE_3D | 'presence-3d-store';
+
+export type Store<T> = T extends GlobalStore
   ? StoreApi<typeof useGlobalStore>
-  : T extends StoreType.WHO_IS_ONLINE
+  : T extends WhoIsOnlineStore
   ? StoreApi<typeof useWhoIsOnlineStore>
-  : T extends StoreType.VIDEO
+  : T extends VideoStore
   ? StoreApi<typeof useVideoStore>
-  : T extends StoreType.PRESENCE_3D
+  : T extends Presence3DStore
   ? StoreApi<typeof usePresence3DStore>
   : never;
 export type StoresTypes = typeof StoreType;

--- a/src/components/base/index.test.ts
+++ b/src/components/base/index.test.ts
@@ -10,6 +10,7 @@ import { useStore } from '../../common/utils/use-store';
 import { Configuration } from '../../services/config/types';
 import { EventBus } from '../../services/event-bus';
 import { IOC } from '../../services/io';
+import { Presence3DManager } from '../../services/presence-3d-manager';
 import { AblyRealtimeService } from '../../services/realtime';
 import { useGlobalStore } from '../../services/stores';
 import { ComponentNames } from '../types';
@@ -75,6 +76,7 @@ describe('BaseComponent', () => {
         config: MOCK_CONFIG,
         eventBus: EVENT_BUS_MOCK,
         roomState: ROOM_STATE_MOCK,
+        Presence3DManagerService: Presence3DManager,
         useStore,
       });
 
@@ -95,6 +97,7 @@ describe('BaseComponent', () => {
       ablyMock['isDomainWhitelisted'] = false;
 
       DummyComponentInstance.attach({
+        Presence3DManagerService: Presence3DManager,
         ioc: new IOC(MOCK_LOCAL_PARTICIPANT),
         realtime: ablyMock as AblyRealtimeService,
         config: MOCK_CONFIG,
@@ -115,6 +118,7 @@ describe('BaseComponent', () => {
       expect(DummyComponentInstance.attach).toBeDefined();
 
       DummyComponentInstance.attach({
+        Presence3DManagerService: Presence3DManager,
         ioc: new IOC(MOCK_LOCAL_PARTICIPANT),
         realtime: REALTIME_MOCK,
         config: MOCK_CONFIG,
@@ -134,6 +138,7 @@ describe('BaseComponent', () => {
       expect(() => {
         DummyComponentInstance.attach({
           ioc: null as unknown as IOC,
+          Presence3DManagerService: Presence3DManager,
           realtime: null as unknown as AblyRealtimeService,
           config: null as unknown as Configuration,
           eventBus: null as unknown as EventBus,
@@ -150,6 +155,7 @@ describe('BaseComponent', () => {
       expect(DummyComponentInstance.detach).toBeDefined();
 
       DummyComponentInstance.attach({
+        Presence3DManagerService: Presence3DManager,
         ioc: new IOC(MOCK_LOCAL_PARTICIPANT),
         realtime: REALTIME_MOCK,
         config: MOCK_CONFIG,
@@ -172,6 +178,7 @@ describe('BaseComponent', () => {
       DummyComponentInstance['destroy'] = jest.fn();
 
       DummyComponentInstance.attach({
+        Presence3DManagerService: Presence3DManager,
         ioc: new IOC(MOCK_LOCAL_PARTICIPANT),
         realtime: REALTIME_MOCK,
         config: MOCK_CONFIG,

--- a/src/components/base/types.ts
+++ b/src/components/base/types.ts
@@ -2,6 +2,7 @@ import { Store, StoreType } from '../../common/types/stores.types';
 import { Configuration } from '../../services/config/types';
 import { EventBus } from '../../services/event-bus';
 import { IOC } from '../../services/io';
+import { Presence3DManager } from '../../services/presence-3d-manager';
 import { AblyRealtimeService } from '../../services/realtime';
 import { RoomStateService } from '../../services/roomState';
 import { useGlobalStore } from '../../services/stores';
@@ -13,6 +14,7 @@ export interface DefaultAttachComponentOptions {
   eventBus: EventBus;
   useStore: <T extends StoreType>(name: T) => Store<T>;
   roomState: RoomStateService;
+  Presence3DManagerService: typeof Presence3DManager;
 }
 
 export type GlobalStore = {

--- a/src/components/comments/index.test.ts
+++ b/src/components/comments/index.test.ts
@@ -11,6 +11,7 @@ import sleep from '../../common/utils/sleep';
 import { useStore } from '../../common/utils/use-store';
 import ApiService from '../../services/api';
 import { IOC } from '../../services/io';
+import { Presence3DManager } from '../../services/presence-3d-manager';
 import { RoomStateService } from '../../services/roomState';
 import { useGlobalStore } from '../../services/stores';
 import { CommentsFloatButton } from '../../web-components';
@@ -86,6 +87,7 @@ describe('Comments', () => {
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
       roomState: ROOM_STATE_MOCK,
+      Presence3DManagerService: Presence3DManager,
       useStore,
     });
 
@@ -341,6 +343,7 @@ describe('Comments', () => {
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
       roomState: ROOM_STATE_MOCK,
+      Presence3DManagerService: Presence3DManager,
       useStore,
     });
 
@@ -361,6 +364,7 @@ describe('Comments', () => {
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
       roomState: ROOM_STATE_MOCK,
+      Presence3DManagerService: Presence3DManager,
       useStore,
     });
 

--- a/src/components/form-elements/index.test.ts
+++ b/src/components/form-elements/index.test.ts
@@ -6,6 +6,7 @@ import { ROOM_STATE_MOCK } from '../../../__mocks__/roomState.mock';
 import { StoreType } from '../../common/types/stores.types';
 import { useStore } from '../../common/utils/use-store';
 import { IOC } from '../../services/io';
+import { Presence3DManager } from '../../services/presence-3d-manager';
 import { ComponentNames } from '../types';
 
 import { FieldEvents } from './types';
@@ -33,6 +34,7 @@ describe('form elements', () => {
       realtime: Object.assign({}, ABLY_REALTIME_MOCK, { hasJoinedRoom: true }),
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
+      Presence3DManagerService: Presence3DManager,
       roomState: ROOM_STATE_MOCK,
       useStore,
     });

--- a/src/components/presence-mouse/canvas/index.test.ts
+++ b/src/components/presence-mouse/canvas/index.test.ts
@@ -6,6 +6,7 @@ import { ABLY_REALTIME_MOCK } from '../../../../__mocks__/realtime.mock';
 import { ROOM_STATE_MOCK } from '../../../../__mocks__/roomState.mock';
 import { useStore } from '../../../common/utils/use-store';
 import { IOC } from '../../../services/io';
+import { Presence3DManager } from '../../../services/presence-3d-manager';
 import { ParticipantMouse } from '../types';
 
 import { PointersCanvas } from './index';
@@ -54,6 +55,7 @@ const createMousePointers = (): PointersCanvas => {
     realtime: ABLY_REALTIME_MOCK,
     config: MOCK_CONFIG,
     eventBus: EVENT_BUS_MOCK,
+    Presence3DManagerService: Presence3DManager,
     roomState: ROOM_STATE_MOCK,
     useStore,
   });

--- a/src/components/presence-mouse/html/index.test.ts
+++ b/src/components/presence-mouse/html/index.test.ts
@@ -5,6 +5,7 @@ import { ABLY_REALTIME_MOCK } from '../../../../__mocks__/realtime.mock';
 import { ROOM_STATE_MOCK } from '../../../../__mocks__/roomState.mock';
 import { useStore } from '../../../common/utils/use-store';
 import { IOC } from '../../../services/io';
+import { Presence3DManager } from '../../../services/presence-3d-manager';
 import { ParticipantMouse } from '../types';
 
 import { PointersHTML } from '.';
@@ -17,6 +18,7 @@ const createMousePointers = (id: string = 'html'): PointersHTML => {
     ioc: new IOC(MOCK_LOCAL_PARTICIPANT),
     realtime: ABLY_REALTIME_MOCK,
     config: MOCK_CONFIG,
+    Presence3DManagerService: Presence3DManager,
     eventBus: EVENT_BUS_MOCK,
     roomState: ROOM_STATE_MOCK,
     useStore,
@@ -381,6 +383,7 @@ describe('MousePointers on HTML', () => {
         config: MOCK_CONFIG,
         eventBus: EVENT_BUS_MOCK,
         ioc: new IOC(MOCK_LOCAL_PARTICIPANT),
+        Presence3DManagerService: Presence3DManager,
         roomState: ROOM_STATE_MOCK,
         useStore,
       });

--- a/src/components/realtime/index.test.ts
+++ b/src/components/realtime/index.test.ts
@@ -8,6 +8,7 @@ import { ABLY_REALTIME_MOCK } from '../../../__mocks__/realtime.mock';
 import { ROOM_STATE_MOCK } from '../../../__mocks__/roomState.mock';
 import { useStore } from '../../common/utils/use-store';
 import { IOC } from '../../services/io';
+import { Presence3DManager } from '../../services/presence-3d-manager';
 
 import { RealtimeComponentState } from './types';
 
@@ -32,6 +33,7 @@ describe('realtime component', () => {
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
       roomState: ROOM_STATE_MOCK,
+      Presence3DManagerService: Presence3DManager,
       useStore,
     });
 

--- a/src/components/video/index.test.ts
+++ b/src/components/video/index.test.ts
@@ -23,6 +23,7 @@ import { Participant, ParticipantType } from '../../common/types/participant.typ
 import { StoreType } from '../../common/types/stores.types';
 import { useStore } from '../../common/utils/use-store';
 import { IOC } from '../../services/io';
+import { Presence3DManager } from '../../services/presence-3d-manager';
 import { ParticipantInfo } from '../../services/realtime/base/types';
 import { RoomStateService } from '../../services/roomState';
 import { VideoFrameState } from '../../services/video-conference-manager/types';
@@ -113,6 +114,7 @@ describe('VideoConference', () => {
       realtime: { ...MOCK_REALTIME, hasJoinedRoom: true } as any,
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
+      Presence3DManagerService: Presence3DManager,
       roomState: { ...ROOM_STATE_MOCK } as RoomStateService,
       useStore,
     });
@@ -132,6 +134,7 @@ describe('VideoConference', () => {
 
     VideoConferenceInstance.attach({
       ioc: new IOC(MOCK_LOCAL_PARTICIPANT),
+      Presence3DManagerService: Presence3DManager,
       realtime: MOCK_REALTIME,
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,

--- a/src/components/who-is-online/index.test.ts
+++ b/src/components/who-is-online/index.test.ts
@@ -13,6 +13,7 @@ import { MeetingColorsHex } from '../../common/types/meeting-colors.types';
 import { StoreType } from '../../common/types/stores.types';
 import { useStore } from '../../common/utils/use-store';
 import { IOC } from '../../services/io';
+import { Presence3DManager } from '../../services/presence-3d-manager';
 import { Following } from '../../services/stores/who-is-online/types';
 import { ComponentNames } from '../types';
 
@@ -60,6 +61,7 @@ describe('Who Is Online', () => {
       realtime: Object.assign({}, ABLY_REALTIME_MOCK, { hasJoinedRoom: true }),
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
+      Presence3DManagerService: Presence3DManager,
       roomState: ROOM_STATE_MOCK,
       useStore,
     });

--- a/src/core/launcher/index.ts
+++ b/src/core/launcher/index.ts
@@ -14,6 +14,7 @@ import config from '../../services/config';
 import { EventBus } from '../../services/event-bus';
 import { IOC } from '../../services/io';
 import LimitsService from '../../services/limits';
+import { Presence3DManager } from '../../services/presence-3d-manager';
 import { AblyRealtimeService } from '../../services/realtime';
 import { ParticipantInfo } from '../../services/realtime/base/types';
 import { RoomStateService } from '../../services/roomState';
@@ -96,6 +97,7 @@ export class Launcher extends Observable implements DefaultLauncher {
       eventBus: this.eventBus,
       useStore,
       roomState: this.roomState,
+      Presence3DManagerService: Presence3DManager,
     });
 
     this.activeComponents.push(component.name);


### PR DESCRIPTION
An error was happening while trying to use the previous lab version from sdk in the 3d plugins. Both the StoreType enum and the Presence3dManager class needed to be imported from the SDK, but this meant generating conflicts because the web-components were redefined and all that. 

By passing the class through the params so the plugins could create new instances of the Presence 3D Manager without importing anything, and by making sure that the Stores would work even without using any enums, these problems are solved.