### PR TITLE
fix: make sure that hosts are only validated after list is initialized

### DIFF
--- a/src/components/video/index.test.ts
+++ b/src/components/video/index.test.ts
@@ -162,6 +162,7 @@ describe('VideoConference', () => {
 
   describe('host handler', () => {
     beforeEach(() => {
+      VideoConferenceInstance['initializedList'] = true;
       VideoConferenceInstance['participantsTypes'][MOCK_LOCAL_PARTICIPANT.id] =
         ParticipantType.HOST;
       const { participants } = VideoConferenceInstance['useStore'](StoreType.GLOBAL);

--- a/src/components/video/index.ts
+++ b/src/components/video/index.ts
@@ -48,6 +48,7 @@ export class VideoConference extends BaseComponent {
   private videoConfig: VideoManagerOptions;
   private params?: VideoComponentOptions;
   private participantsTypes: Record<string, ParticipantType> = {};
+  private initializedList: boolean = false;
   private hasSetHost = false;
 
   private kickParticipantsOnHostLeave = false;
@@ -159,6 +160,8 @@ export class VideoConference extends BaseComponent {
       });
 
       this.participantsTypes[this.localParticipant.id] = this.localParticipant.type;
+
+      this.initializedList = true;
       this.validateIfInTheRoomHasHost();
     });
   };
@@ -822,6 +825,8 @@ export class VideoConference extends BaseComponent {
    * @returns {void}
    */
   private validateIfInTheRoomHasHost = (): void => {
+    if (!this.initializedList) return;
+
     const { hostId } = this.useStore(StoreType.VIDEO);
     const { participants } = this.useStore(StoreType.GLOBAL);
     const participantsList = Object.values(participants.value);


### PR DESCRIPTION
In some rare cases, it was trying to validate and set hosts even before confirming which types other participants are, leading to a new participant being assigned as the host even if there already was a host in the room. Setting a flag right after processing the list and then early returning if the flag is still false seems to be the most direct and failproof way of ensuring the host is only set at the right time