### PR TITLE
fix: properly fetch room state

### DIFF
--- a/src/components/base/index.test.ts
+++ b/src/components/base/index.test.ts
@@ -75,7 +75,6 @@ describe('BaseComponent', () => {
         realtime: ABLY_REALTIME_MOCK,
         config: MOCK_CONFIG,
         eventBus: EVENT_BUS_MOCK,
-        roomState: ROOM_STATE_MOCK,
         Presence3DManagerService: Presence3DManager,
         useStore,
       });
@@ -102,7 +101,6 @@ describe('BaseComponent', () => {
         realtime: ablyMock as AblyRealtimeService,
         config: MOCK_CONFIG,
         eventBus: EVENT_BUS_MOCK,
-        roomState: ROOM_STATE_MOCK,
         useStore,
       });
 
@@ -123,7 +121,6 @@ describe('BaseComponent', () => {
         realtime: REALTIME_MOCK,
         config: MOCK_CONFIG,
         eventBus: EVENT_BUS_MOCK,
-        roomState: ROOM_STATE_MOCK,
         useStore,
       });
 
@@ -142,7 +139,6 @@ describe('BaseComponent', () => {
           realtime: null as unknown as AblyRealtimeService,
           config: null as unknown as Configuration,
           eventBus: null as unknown as EventBus,
-          roomState: ROOM_STATE_MOCK,
           useStore: null as unknown as typeof useStore,
         });
       }).toThrowError();
@@ -160,7 +156,6 @@ describe('BaseComponent', () => {
         realtime: REALTIME_MOCK,
         config: MOCK_CONFIG,
         eventBus: EVENT_BUS_MOCK,
-        roomState: ROOM_STATE_MOCK,
         useStore,
       });
 
@@ -183,7 +178,6 @@ describe('BaseComponent', () => {
         realtime: REALTIME_MOCK,
         config: MOCK_CONFIG,
         eventBus: EVENT_BUS_MOCK,
-        roomState: ROOM_STATE_MOCK,
         useStore,
       });
 

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -25,7 +25,6 @@ export abstract class BaseComponent extends Observable {
   protected unsubscribeFrom: Array<(id: unknown) => void> = [];
   protected useStore = useStore.bind(this) as typeof useStore;
   protected room: Socket.Room;
-  protected roomState: RoomStateService;
 
   /**
    * @function attach
@@ -41,7 +40,7 @@ export abstract class BaseComponent extends Observable {
       throw new Error(message);
     }
 
-    const { realtime, config: globalConfig, eventBus, ioc, roomState } = params;
+    const { realtime, config: globalConfig, eventBus, ioc } = params;
     const { isDomainWhitelisted, hasJoinedRoom } = this.useStore(StoreType.GLOBAL);
 
     if (!isDomainWhitelisted.value) {
@@ -56,7 +55,6 @@ export abstract class BaseComponent extends Observable {
     this.isAttached = true;
     this.ioc = ioc;
     this.room = ioc.createRoom(this.name);
-    this.roomState = roomState;
 
     if (!hasJoinedRoom.value) {
       this.logger.log(`${this.name} @ attach - not joined yet`);

--- a/src/components/base/types.ts
+++ b/src/components/base/types.ts
@@ -13,7 +13,6 @@ export interface DefaultAttachComponentOptions {
   config: Configuration;
   eventBus: EventBus;
   useStore: <T extends StoreType>(name: T) => Store<T>;
-  roomState: RoomStateService;
   Presence3DManagerService: typeof Presence3DManager;
 }
 

--- a/src/components/comments/index.test.ts
+++ b/src/components/comments/index.test.ts
@@ -86,7 +86,6 @@ describe('Comments', () => {
       realtime: Object.assign({}, ABLY_REALTIME_MOCK, { hasJoinedRoom: true }),
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
-      roomState: ROOM_STATE_MOCK,
       Presence3DManagerService: Presence3DManager,
       useStore,
     });
@@ -342,7 +341,6 @@ describe('Comments', () => {
       realtime: Object.assign({}, ABLY_REALTIME_MOCK, { hasJoinedRoom: true }),
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
-      roomState: ROOM_STATE_MOCK,
       Presence3DManagerService: Presence3DManager,
       useStore,
     });
@@ -363,7 +361,6 @@ describe('Comments', () => {
       realtime: Object.assign({}, ABLY_REALTIME_MOCK, { hasJoinedRoom: true }),
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
-      roomState: ROOM_STATE_MOCK,
       Presence3DManagerService: Presence3DManager,
       useStore,
     });

--- a/src/components/form-elements/index.test.ts
+++ b/src/components/form-elements/index.test.ts
@@ -35,7 +35,6 @@ describe('form elements', () => {
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
       Presence3DManagerService: Presence3DManager,
-      roomState: ROOM_STATE_MOCK,
       useStore,
     });
   });

--- a/src/components/presence-mouse/canvas/index.test.ts
+++ b/src/components/presence-mouse/canvas/index.test.ts
@@ -56,7 +56,6 @@ const createMousePointers = (): PointersCanvas => {
     config: MOCK_CONFIG,
     eventBus: EVENT_BUS_MOCK,
     Presence3DManagerService: Presence3DManager,
-    roomState: ROOM_STATE_MOCK,
     useStore,
   });
 

--- a/src/components/presence-mouse/html/index.test.ts
+++ b/src/components/presence-mouse/html/index.test.ts
@@ -20,7 +20,6 @@ const createMousePointers = (id: string = 'html'): PointersHTML => {
     config: MOCK_CONFIG,
     Presence3DManagerService: Presence3DManager,
     eventBus: EVENT_BUS_MOCK,
-    roomState: ROOM_STATE_MOCK,
     useStore,
   });
 
@@ -384,7 +383,6 @@ describe('MousePointers on HTML', () => {
         eventBus: EVENT_BUS_MOCK,
         ioc: new IOC(MOCK_LOCAL_PARTICIPANT),
         Presence3DManagerService: Presence3DManager,
-        roomState: ROOM_STATE_MOCK,
         useStore,
       });
 

--- a/src/components/realtime/index.test.ts
+++ b/src/components/realtime/index.test.ts
@@ -32,7 +32,6 @@ describe('realtime component', () => {
       realtime: Object.assign({}, ABLY_REALTIME_MOCK, { hasJoinedRoom: true }),
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
-      roomState: ROOM_STATE_MOCK,
       Presence3DManagerService: Presence3DManager,
       useStore,
     });

--- a/src/components/video/index.test.ts
+++ b/src/components/video/index.test.ts
@@ -115,9 +115,10 @@ describe('VideoConference', () => {
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
       Presence3DManagerService: Presence3DManager,
-      roomState: { ...ROOM_STATE_MOCK } as RoomStateService,
       useStore,
     });
+
+    VideoConferenceInstance['onFrameStateChange'](VideoFrameState.INITIALIZED);
   });
 
   test('should not show avatar settings if local participant has avatar', () => {
@@ -138,7 +139,6 @@ describe('VideoConference', () => {
       realtime: MOCK_REALTIME,
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
-      roomState: ROOM_STATE_MOCK,
       useStore,
     });
 
@@ -422,6 +422,9 @@ describe('VideoConference', () => {
     });
 
     test('should not initialize video when frame is not initialized', () => {
+      jest.clearAllMocks();
+      jest.restoreAllMocks();
+
       VideoConferenceInstance['onFrameStateChange'](VideoFrameState.INITIALIZING);
 
       expect(VIDEO_MANAGER_MOCK.start).not.toHaveBeenCalled();

--- a/src/components/who-is-online/index.test.ts
+++ b/src/components/who-is-online/index.test.ts
@@ -62,7 +62,6 @@ describe('Who Is Online', () => {
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
       Presence3DManagerService: Presence3DManager,
-      roomState: ROOM_STATE_MOCK,
       useStore,
     });
 

--- a/src/core/launcher/index.ts
+++ b/src/core/launcher/index.ts
@@ -32,7 +32,6 @@ export class Launcher extends Observable implements DefaultLauncher {
   private activeComponentsInstances: Partial<BaseComponent>[] = [];
 
   private ioc: IOC;
-  private roomState: RoomStateService;
   private LauncherRealtimeRoom: Socket.Room;
   private realtime: AblyRealtimeService;
   private eventBus: EventBus = new EventBus();
@@ -62,7 +61,6 @@ export class Launcher extends Observable implements DefaultLauncher {
     group.publish(participantGroup);
     this.ioc = new IOC(localParticipant.value);
     this.LauncherRealtimeRoom = this.ioc.createRoom('launcher');
-    this.roomState = new RoomStateService(this.ioc.createRoom('video-conference'), this.logger);
 
     // internal events without realtime
     this.eventBus = new EventBus();
@@ -96,7 +94,6 @@ export class Launcher extends Observable implements DefaultLauncher {
       config: config.configuration,
       eventBus: this.eventBus,
       useStore,
-      roomState: this.roomState,
       Presence3DManagerService: Presence3DManager,
     });
 

--- a/src/services/roomState/index.test.ts
+++ b/src/services/roomState/index.test.ts
@@ -58,7 +58,6 @@ describe('roomState', () => {
     test('should subscribe to room events', () => {
       const onParticipantLeave = jest.spyOn(serviceInstance as any, 'onParticipantLeave');
       const onPresenceEnter = jest.spyOn(serviceInstance as any, 'onPresenceEnter');
-      const onJoinRoom = jest.spyOn(serviceInstance as any, 'onJoinRoom');
       const updateLocalRoomState = jest.spyOn(serviceInstance as any, 'updateLocalRoomState');
 
       serviceInstance['join']();
@@ -71,7 +70,7 @@ describe('roomState', () => {
         PresenceEvents.JOINED_ROOM,
         onPresenceEnter,
       );
-      expect(serviceInstance['room'].on).toBeCalledWith(RoomEvents.JOINED_ROOM, onJoinRoom);
+
       expect(serviceInstance['room'].on).toBeCalledWith(
         RoomPropertiesEvents.UPDATE,
         updateLocalRoomState,
@@ -288,7 +287,7 @@ describe('roomState', () => {
     });
   });
 
-  describe('onJoinRoom', () => {
+  describe('start', () => {
     test('should initialize room properties if no last message', async () => {
       const history = jest.fn().mockImplementation((cb) => cb({ events: [] }));
       serviceInstance['room'].history = history;
@@ -301,7 +300,7 @@ describe('roomState', () => {
       const updateLocalRoomState = jest.spyOn(serviceInstance as any, 'updateLocalRoomState');
       const publishStateUpdate = jest.spyOn(serviceInstance as any, 'publishStateUpdate');
 
-      await serviceInstance['onJoinRoom']();
+      await serviceInstance['start']();
 
       expect(fetchRoomProperties).toBeCalled();
       expect(initializeRoomProperties).toBeCalled();
@@ -320,7 +319,7 @@ describe('roomState', () => {
 
       fetchRoomProperties.mockResolvedValue({ isGridModeEnabled: true });
 
-      await serviceInstance['onJoinRoom']();
+      await serviceInstance['start']();
 
       expect(fetchRoomProperties).toBeCalled();
       expect(initializeRoomProperties).not.toBeCalled();
@@ -452,7 +451,7 @@ describe('roomState', () => {
 
       expect(serviceInstance['isSyncFrozen']).toBe(true);
       expect(serviceInstance['room'].presence.off).toBeCalledTimes(2);
-      expect(serviceInstance['room'].off).toBeCalledTimes(2);
+      expect(serviceInstance['room'].off).toBeCalledTimes(1);
     });
 
     test('should unfreeze sync', () => {
@@ -472,7 +471,7 @@ describe('roomState', () => {
 
       serviceInstance['destroy']();
 
-      expect(off).toBeCalledTimes(4);
+      expect(off).toBeCalledTimes(3);
     });
   });
 });


### PR DESCRIPTION
Fix the bug that made participants joining a room not properly set the room properties for themselves (For example: in a room where transcript is on, new participants would join the room with transcript off).

There were two problems: 
- Instead of getting the most recent event in the room, it was getting the oldest. 
- The room state service was starting to soon and trying to set the room properties even before the frame initialized. 

The fix for the first problem was changing `events[0]` to `events.pop()`

The fix for the second problem was only instantiating the service after receiving the confirmation that the frame was initialized. Right after that, it tries to fetch the room properties, instead of waiting for the participant joined room event. The participant already joined the room even before the service was instantiated, so it would never fetch the room properties otherwise. 
In a hypothetical rare case where the participant has not joined the room already, there is a loop that calls the start method of the room state service until the participant has joined