### PR TITLE
fix: slot assignment dont syncing in the stores

### DIFF
--- a/src/core/launcher/index.ts
+++ b/src/core/launcher/index.ts
@@ -405,29 +405,15 @@ export class Launcher extends Observable implements DefaultLauncher {
   private onParticipantJoinedIOC = async (
     presence: Socket.PresenceEvent<Participant>,
   ): Promise<void> => {
-    const { participants, localParticipant } = useStore(StoreType.GLOBAL);
+    const { localParticipant } = useStore(StoreType.GLOBAL);
     if (presence.id !== localParticipant.value.id) return;
 
     // Assign a slot to the participant
-    const slot = new SlotService(this.LauncherRealtimeRoom, localParticipant.value);
-    const slotData = await slot.assignSlot();
-
-    localParticipant.publish({
-      ...localParticipant.value,
-      slot: slotData,
-    });
-
-    const participantsMap = { ...participants.value };
-    participantsMap[presence.id] = {
-      ...participants.value[presence.id],
-      ...localParticipant.value,
-      timestamp: presence.timestamp,
-      slot: slotData,
-    };
+    const slot = new SlotService(this.LauncherRealtimeRoom);
+    await slot.assignSlot();
 
     this.timestamp = presence.timestamp;
 
-    participants.publish(participantsMap);
     this.LauncherRealtimeRoom.presence.update(localParticipant.value);
 
     this.logger.log('launcher service @ onParticipantJoined - local participant joined');
@@ -492,6 +478,7 @@ export class Launcher extends Observable implements DefaultLauncher {
     }
 
     const { participants } = useStore(StoreType.GLOBAL);
+
     if (!participants.value[presence.id]) {
       this.publish(ParticipantEvent.JOINED, presence.data);
     }

--- a/src/services/slot/index.test.ts
+++ b/src/services/slot/index.test.ts
@@ -20,11 +20,10 @@ describe('slot service', () => {
       id: '123',
     } as any;
 
-    const instance = new SlotService(room, participant);
+    const instance = new SlotService(room);
     const result = await instance.assignSlot();
 
     expect(instance['slotIndex']).toBeDefined();
-    expect(instance['participant'].slot).toBeDefined();
     expect(result).toEqual({
       index: expect.any(Number),
       color: expect.any(String),
@@ -47,15 +46,10 @@ describe('slot service', () => {
       },
     } as any;
 
-    const participant = {
-      id: '123',
-    } as any;
-
-    const instance = new SlotService(room, participant);
+    const instance = new SlotService(room);
     await instance.assignSlot();
 
     expect(instance['slotIndex']).toBeUndefined();
-    expect(instance['participant'].slot).toBeUndefined();
   });
 
   test('if the slot is already in use, it should assign a new slot', async () => {
@@ -85,11 +79,10 @@ describe('slot service', () => {
       id: '123',
     } as any;
 
-    const instance = new SlotService(room, participant);
+    const instance = new SlotService(room);
     const result = await instance.assignSlot();
 
     expect(instance['slotIndex']).toBeDefined();
-    expect(instance['participant'].slot).toBeDefined();
     expect(result).toEqual({
       index: expect.any(Number),
       color: expect.any(String),


### PR DESCRIPTION


It ensures that any changes made to the slots will update the global store and the default real-time room.
