### PR TITLE
feat: add a default channel to realtime component

### DIFF
--- a/src/components/realtime/channel.ts
+++ b/src/components/realtime/channel.ts
@@ -46,10 +46,9 @@ export class Channel extends Observable {
 
   /**
    * @function publish
-   * @description Publish an event
-   * @param type - event type
-   * @param data - event data
-   * @returns {void}
+   * @description Publishes an event with optional data to the channel.
+   * @param event - The name of the event to publish.
+   * @param data - Optional data to be sent along with the event.
    */
   public publish = throttle((event: string, data?: unknown): void => {
     if (Object.values(ComponentLifeCycleEvent).includes(event as ComponentLifeCycleEvent)) {
@@ -69,10 +68,10 @@ export class Channel extends Observable {
 
   /**
    * @function subscribe
-   * @description subscribe to event
-   * @param event - event name
-   * @param callback - callback function
-   * @returns {void}
+   * @description Subscribes to a specific event and registers a callback function to handle the received data.
+   *  If the channel is not yet available, the subscription will be queued and executed once the channel is joined.
+   * @param event - The name of the event to subscribe to.
+   * @param callback - The callback function to handle the received data. It takes a parameter of type `RealtimeMessage` or `string`.
    */
   public subscribe = (event: string, callback: (data: RealtimeMessage | string) => void): void => {
     if (this.state !== RealtimeChannelState.CONNECTED) {
@@ -89,10 +88,9 @@ export class Channel extends Observable {
 
   /**
    * @function unsubscribe
-   * @description - unsubscribe from event
-   * @param event - event name
-   * @param callback - callback function
-   * @returns {void}
+   * @description Unsubscribes from a specific event.
+   * @param event - The event to unsubscribe from.
+   * @param callback - An optional callback function to be called when the event is unsubscribed.
    */
   public unsubscribe = (
     event: string,

--- a/src/components/realtime/channel.ts
+++ b/src/components/realtime/channel.ts
@@ -74,7 +74,7 @@ export class Channel extends Observable {
    * @param callback - callback function
    * @returns {void}
    */
-  public subscribe = (event: string, callback: (data: RealtimeMessage) => void): void => {
+  public subscribe = (event: string, callback: (data: RealtimeMessage | string) => void): void => {
     if (this.state !== RealtimeChannelState.CONNECTED) {
       this.callbacksToSubscribeWhenJoined.push({ event, callback });
       return;
@@ -94,7 +94,10 @@ export class Channel extends Observable {
    * @param callback - callback function
    * @returns {void}
    */
-  public unsubscribe = (event: string, callback?: (data: RealtimeMessage) => void): void => {
+  public unsubscribe = (
+    event: string,
+    callback?: (data: RealtimeMessage | string) => void,
+  ): void => {
     if (!this.observers[event]) return;
 
     this.observers[event].unsubscribe(callback);

--- a/src/components/realtime/index.ts
+++ b/src/components/realtime/index.ts
@@ -5,14 +5,26 @@ import { BaseComponent } from '../base';
 import { ComponentNames } from '../types';
 
 import { Channel } from './channel';
-import { RealtimeComponentEvent, RealtimeComponentState } from './types';
+import {
+  RealtimeChannelEvent,
+  RealtimeChannelState,
+  RealtimeComponentEvent,
+  RealtimeComponentState,
+  RealtimeMessage,
+} from './types';
 
 export class Realtime extends BaseComponent {
+  private channel: Channel;
+
   protected logger: Logger;
   public name: ComponentNames;
   private declare localParticipant: Participant;
   private state: RealtimeComponentState = RealtimeComponentState.STOPPED;
   private channels: Map<string, Channel> = new Map();
+  private callbacksToSubscribeWhenJoined: Array<{
+    event: string;
+    callback: (data: unknown) => void;
+  }> = [];
 
   constructor() {
     super();
@@ -23,6 +35,12 @@ export class Realtime extends BaseComponent {
     localParticipant.subscribe();
   }
 
+  /**
+   * @function connect
+   * @description - connect to a channel
+   * @param name - channel name
+   * @returns {Channel}
+   */
   public connect(name: string): Channel {
     if (this.state !== RealtimeComponentState.STARTED) {
       const message =
@@ -44,9 +62,40 @@ export class Realtime extends BaseComponent {
     return channel;
   }
 
+  public subscribe = (event: string, callback: (data: RealtimeMessage | string) => void): void => {
+    if (!this.channel) {
+      this.callbacksToSubscribeWhenJoined.push({ event, callback });
+      return;
+    }
+
+    this.channel?.subscribe(event, callback);
+  };
+
+  public publish = (event: string, data?: unknown): void => {
+    this.channel?.publish(event, data);
+  };
+
+  public unsubscribe = (event: string, callback?: (data: RealtimeMessage) => void): void => {
+    this.channel?.unsubscribe(event, callback);
+  };
+
   protected start(): void {
     this.logger.log('started');
-    this.changeState(RealtimeComponentState.STARTED);
+    this.channel = new Channel('default', this.ioc, this.localParticipant);
+
+    this.channel.subscribe(RealtimeChannelEvent.REALTIME_CHANNEL_STATE_CHANGED, (state) => {
+      if (state !== RealtimeChannelState.CONNECTED) return;
+
+      this.callbacksToSubscribeWhenJoined.forEach(({ event, callback }) => {
+        this.channel.subscribe(event, callback);
+      });
+
+      this.changeState(RealtimeComponentState.STARTED);
+      this.callbacksToSubscribeWhenJoined = [];
+
+      this.channel.unsubscribe(RealtimeChannelEvent.REALTIME_CHANNEL_STATE_CHANGED);
+      this.channels.set('default', this.channel);
+    });
   }
 
   protected destroy(): void {
@@ -74,6 +123,9 @@ export class Realtime extends BaseComponent {
     this.logger.log('realtime component @ changeState - state changed', state);
     this.state = state;
 
-    this.publish(RealtimeComponentEvent.REALTIME_STATE_CHANGED, this.state);
+    this.channel?.['publishEventToClient'](
+      RealtimeComponentEvent.REALTIME_STATE_CHANGED,
+      this.state,
+    );
   }
 }

--- a/src/components/realtime/index.ts
+++ b/src/components/realtime/index.ts
@@ -62,6 +62,13 @@ export class Realtime extends BaseComponent {
     return channel;
   }
 
+  /**
+   * @function subscribe
+   * @description Subscribes to a specific event and registers a callback function to handle the received data.
+   *  If the channel is not yet available, the subscription will be queued and executed once the channel is joined.
+   * @param event - The name of the event to subscribe to.
+   * @param callback - The callback function to handle the received data. It takes a parameter of type `RealtimeMessage` or `string`.
+   */
   public subscribe = (event: string, callback: (data: RealtimeMessage | string) => void): void => {
     if (!this.channel) {
       this.callbacksToSubscribeWhenJoined.push({ event, callback });
@@ -71,10 +78,22 @@ export class Realtime extends BaseComponent {
     this.channel?.subscribe(event, callback);
   };
 
+  /**
+   * @function publish
+   * @description Publishes an event with optional data to the channel.
+   * @param event - The name of the event to publish.
+   * @param data - Optional data to be sent along with the event.
+   */
   public publish = (event: string, data?: unknown): void => {
     this.channel?.publish(event, data);
   };
 
+  /**
+   * @function unsubscribe
+   * @description Unsubscribes from a specific event.
+   * @param event - The event to unsubscribe from.
+   * @param callback - An optional callback function to be called when the event is unsubscribed.
+   */
   public unsubscribe = (event: string, callback?: (data: RealtimeMessage) => void): void => {
     this.channel?.unsubscribe(event, callback);
   };


### PR DESCRIPTION
Add a default channel to handle the messages if the client don´t want to create channels. 

