### PR TITLE
fix: properly unsubscribe from subject that was subscribed to twice

### DIFF
--- a/src/common/types/stores.types.ts
+++ b/src/common/types/stores.types.ts
@@ -13,7 +13,7 @@ export enum StoreType {
 
 type Subject<T extends (...args: any[]) => any, K extends keyof ReturnType<T>> = ReturnType<T>[K];
 
-type StoreApiWithoutDestroy<T extends (...args: any[]) => any> = {
+type IncompleteStoreApi<T extends (...args: any[]) => any> = {
   [K in keyof ReturnType<T>]: {
     subscribe(callback?: (value: Subject<T, K>['value']) => void): void;
     subject: Subject<T, K>;
@@ -22,8 +22,9 @@ type StoreApiWithoutDestroy<T extends (...args: any[]) => any> = {
   };
 };
 
-type StoreApi<T extends (...args: any[]) => any> = Omit<StoreApiWithoutDestroy<T>, 'destroy'> & {
+type StoreApi<T extends (...args: any[]) => any> = IncompleteStoreApi<T> & {
   destroy(): void;
+  restart(): void;
 };
 
 type GlobalStore = StoreType.GLOBAL | `${StoreType.GLOBAL}`;

--- a/src/components/video/index.test.ts
+++ b/src/components/video/index.test.ts
@@ -7,7 +7,6 @@ import { EVENT_BUS_MOCK } from '../../../__mocks__/event-bus.mock';
 import { MOCK_OBSERVER_HELPER } from '../../../__mocks__/observer-helper.mock';
 import { MOCK_AVATAR, MOCK_LOCAL_PARTICIPANT } from '../../../__mocks__/participants.mock';
 import { ABLY_REALTIME_MOCK } from '../../../__mocks__/realtime.mock';
-import { ROOM_STATE_MOCK } from '../../../__mocks__/roomState.mock';
 import {
   DeviceEvent,
   FrameEvent,
@@ -25,7 +24,6 @@ import { useStore } from '../../common/utils/use-store';
 import { IOC } from '../../services/io';
 import { Presence3DManager } from '../../services/presence-3d-manager';
 import { ParticipantInfo } from '../../services/realtime/base/types';
-import { RoomStateService } from '../../services/roomState';
 import { VideoFrameState } from '../../services/video-conference-manager/types';
 import { ComponentNames } from '../types';
 
@@ -97,11 +95,12 @@ describe('VideoConference', () => {
   let VideoConferenceInstance: VideoConference;
 
   const { localParticipant, hasJoinedRoom } = useStore(StoreType.GLOBAL);
-  localParticipant.publish(MOCK_LOCAL_PARTICIPANT);
-  hasJoinedRoom.publish(true);
   beforeEach(() => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
+
+    localParticipant.publish(MOCK_LOCAL_PARTICIPANT);
+    hasJoinedRoom.publish(true);
 
     VideoConferenceInstance = new VideoConference({
       userType: 'host',
@@ -118,6 +117,7 @@ describe('VideoConference', () => {
       useStore,
     });
 
+    VideoConferenceInstance['startVideo']();
     VideoConferenceInstance['onFrameStateChange'](VideoFrameState.INITIALIZED);
   });
 

--- a/src/components/who-is-online/index.test.ts
+++ b/src/components/who-is-online/index.test.ts
@@ -7,7 +7,6 @@ import {
   MOCK_ABLY_PARTICIPANT_DATA_1,
 } from '../../../__mocks__/participants.mock';
 import { ABLY_REALTIME_MOCK } from '../../../__mocks__/realtime.mock';
-import { ROOM_STATE_MOCK } from '../../../__mocks__/roomState.mock';
 import { RealtimeEvent, WhoIsOnlineEvent } from '../../common/types/events.types';
 import { MeetingColorsHex } from '../../common/types/meeting-colors.types';
 import { StoreType } from '../../common/types/stores.types';

--- a/src/core/launcher/index.test.ts
+++ b/src/core/launcher/index.test.ts
@@ -13,7 +13,6 @@ import { DefaultAttachComponentOptions } from '../../components/base/types';
 import { ComponentNames } from '../../components/types';
 import { IOC } from '../../services/io';
 import LimitsService from '../../services/limits';
-import { AblyParticipant } from '../../services/realtime/ably/types';
 import { useGlobalStore } from '../../services/stores';
 
 import { LauncherFacade, LauncherOptions } from './types';

--- a/src/services/stores/presence3D/index.ts
+++ b/src/services/stores/presence3D/index.ts
@@ -20,6 +20,7 @@ class Presence3DStore {
 
   public destroy() {
     this.hasJoined3D.destroy();
+    this.participants.destroy();
   }
 }
 

--- a/src/services/stores/subject/index.test.ts
+++ b/src/services/stores/subject/index.test.ts
@@ -82,7 +82,7 @@ describe('base subject for all stores', () => {
       const unsubscribe = jest.fn();
 
       instance['subscribe'](testValues.id, callback);
-      instance['subscriptions'].get(testValues.id)!.unsubscribe = unsubscribe;
+      instance['subscriptions'].get(testValues.id)![0].unsubscribe = unsubscribe;
 
       instance['unsubscribe'](testValues.id);
 
@@ -97,16 +97,14 @@ describe('base subject for all stores', () => {
       instance = subject<string>(testValues.str1);
 
       const callback = jest.fn();
-      const unsubscribe = jest.fn();
 
       instance['subscribe'](testValues.id, callback);
-      instance['subscriptions'].get(testValues.id)!.unsubscribe = unsubscribe;
 
       instance['destroy']();
 
       expect(instance['subscriptions'].size).toBe(0);
       expect(instance['subscriptions'].get(testValues.id)).toBeUndefined();
-      expect(unsubscribe).toHaveBeenCalled();
+      expect(instance.state).toBe(instance['firstState']);
     });
   });
 

--- a/src/services/stores/who-is-online/index.ts
+++ b/src/services/stores/who-is-online/index.ts
@@ -42,8 +42,6 @@ export class WhoIsOnlineStore {
     this.everyoneFollowsMe.destroy();
     this.privateMode.destroy();
     this.following.destroy();
-
-    instance.value = null;
   }
 }
 


### PR DESCRIPTION
- Identify and store multiple subscriptions to the same subject in a store using the same `subscriptionId`
- Restart the subject to its initial state after it is destroyed in case the room starts again
