### PR TITLE
fix: errors on destroy room

### DIFF
--- a/src/components/video/index.ts
+++ b/src/components/video/index.ts
@@ -523,12 +523,12 @@ export class VideoConference extends BaseComponent {
   private onParticipantLeft = (_: Participant): void => {
     this.logger.log('video conference @ on participant left', this.localParticipant);
 
-    this.videoManager.leave();
     this.connectionService.removeListeners();
     this.publish(MeetingEvent.DESTROY);
     this.publish(MeetingEvent.MY_PARTICIPANT_LEFT, this.localParticipant);
 
     this.unsubscribeFromVideoEvents();
+    this.videoManager.leave();
     this.videoManager = undefined;
     this.connectionService = undefined;
 

--- a/src/core/launcher/index.ts
+++ b/src/core/launcher/index.ts
@@ -174,11 +174,9 @@ export class Launcher extends Observable implements DefaultLauncher {
       this.removeComponent(component);
     });
 
-    const { localParticipant } = useStore(StoreType.GLOBAL);
-
     this.activeComponents = [];
     this.activeComponentsInstances = [];
-    localParticipant.publish(undefined);
+
     useGlobalStore().destroy();
 
     this.eventBus.destroy();

--- a/src/services/stores/global/index.ts
+++ b/src/services/stores/global/index.ts
@@ -7,7 +7,7 @@ import subject from '../subject';
 const instance: Singleton<GlobalStore> = CreateSingleton<GlobalStore>();
 
 export class GlobalStore {
-  public localParticipant = subject<Participant>(null);
+  public localParticipant = subject<Participant>({} as Participant);
   public participants = subject<Record<string, ParticipantInfo>>({});
   public group = subject<Group>(null);
   public isDomainWhitelisted = subject<boolean>(true);


### PR DESCRIPTION
When destroying a room with video, I noticed some errors on the console
Publishing to the stores the localParticipant as undefined was bound to throw some error, since no subscription to the global store was made with the possibility of the local participant being undefined in mind
When destroying the video, the Video Manager was being destroyed before the Video component tried to unsubscribe from the Observers in the VM, so an error was thrown