### PR TITLE
Improve slot assignment and de-assignment

### DIFF
--- a/__mocks__/participants.mock.ts
+++ b/__mocks__/participants.mock.ts
@@ -10,7 +10,6 @@ export const MOCK_AVATAR: Avatar = {
 export const MOCK_LOCAL_PARTICIPANT: Participant = {
   id: 'unit-test-local-participant-id',
   name: 'unit-test-local-participant-name',
-  color: '#000',
   avatar: {
     imageUrl: 'unit-test-avatar-thumbnail.png',
     model3DUrl: 'unit-test-avatar-model.glb',

--- a/src/common/types/participant.types.ts
+++ b/src/common/types/participant.types.ts
@@ -18,7 +18,6 @@ export interface Participant {
   id: string;
   name?: string;
   type?: ParticipantType;
-  color?: string;
   slot?: Slot;
   avatar?: Avatar;
   isHost?: boolean;

--- a/src/components/presence-mouse/canvas/index.ts
+++ b/src/components/presence-mouse/canvas/index.ts
@@ -330,7 +330,7 @@ export class PointersCanvas extends BaseComponent {
     const pointerUser = divPointer.getElementsByClassName('pointer-mouse')[0] as HTMLDivElement;
 
     if (pointerUser) {
-      pointerUser.style.backgroundImage = `url(https://production.cdn.superviz.com/static/mouse-pointers/${mouse.slot.colorName}.svg)`;
+      pointerUser.style.backgroundImage = `url(https://production.cdn.superviz.com/static/mouse-pointers/${mouse.slot?.colorName}.svg)`;
     }
 
     if (mouseUser) {

--- a/src/components/presence-mouse/canvas/index.ts
+++ b/src/components/presence-mouse/canvas/index.ts
@@ -8,6 +8,7 @@ import { Logger } from '../../../common/utils';
 import { BaseComponent } from '../../base';
 import { ComponentNames } from '../../types';
 import { Camera, ParticipantMouse, PresenceMouseProps, Transform } from '../types';
+import { MEETING_COLORS } from '../../../common/types/meeting-colors.types';
 
 export class PointersCanvas extends BaseComponent {
   public name: ComponentNames;
@@ -334,8 +335,8 @@ export class PointersCanvas extends BaseComponent {
     }
 
     if (mouseUser) {
-      mouseUser.style.color = mouse.slot.textColor;
-      mouseUser.style.backgroundColor = mouse.slot.color;
+      mouseUser.style.color = mouse.slot?.textColor ?? '#fff';
+      mouseUser.style.backgroundColor = mouse.slot?.color ?? MEETING_COLORS.gray;
       mouseUser.innerHTML = mouse.name;
     }
 

--- a/src/components/presence-mouse/html/index.ts
+++ b/src/components/presence-mouse/html/index.ts
@@ -16,6 +16,7 @@ import {
   Transform,
   VoidElements,
 } from '../types';
+import { MEETING_COLORS } from '../../../common/types/meeting-colors.types';
 
 export class PointersHTML extends BaseComponent {
   public name: ComponentNames;
@@ -695,8 +696,8 @@ export class PointersHTML extends BaseComponent {
     }
 
     if (mouseUser) {
-      mouseUser.style.color = participant.slot.textColor;
-      mouseUser.style.backgroundColor = participant.slot.color;
+      mouseUser.style.color = participant.slot?.textColor ?? MEETING_COLORS.gray;
+      mouseUser.style.backgroundColor = participant.slot?.color ?? '#fff';
       mouseUser.innerHTML = participant.name;
     }
 

--- a/src/components/presence-mouse/html/index.ts
+++ b/src/components/presence-mouse/html/index.ts
@@ -691,7 +691,7 @@ export class PointersHTML extends BaseComponent {
     const pointerUser = mouseFollower.getElementsByClassName('pointer-mouse')[0] as HTMLDivElement;
 
     if (pointerUser) {
-      pointerUser.style.backgroundImage = `url(https://production.cdn.superviz.com/static/mouse-pointers/${participant.slot.colorName}.svg)`;
+      pointerUser.style.backgroundImage = `url(https://production.cdn.superviz.com/static/mouse-pointers/${participant.slot?.colorName}.svg)`;
     }
 
     if (mouseUser) {

--- a/src/components/video/index.test.ts
+++ b/src/components/video/index.test.ts
@@ -22,6 +22,7 @@ import { useStore } from '../../common/utils/use-store';
 import { IOC } from '../../services/io';
 import { Presence3DManager } from '../../services/presence-3d-manager';
 import { VideoFrameState } from '../../services/video-conference-manager/types';
+import { ParticipantToFrame } from './types';
 
 import { VideoConference } from '.';
 import { MEETING_COLORS } from '../../common/types/meeting-colors.types';
@@ -678,7 +679,6 @@ describe('VideoConference', () => {
           isHost: true,
           avatar: MOCK_AVATAR,
           type: ParticipantType.HOST,
-          color: 'turquoise',
           slot: {
             colorName: 'turquoise',
             index: 0,
@@ -691,14 +691,15 @@ describe('VideoConference', () => {
 
       VideoConferenceInstance['onRealtimeParticipantsDidChange'](participant);
 
-      const expectedParticipants = {
+      const expectedParticipants: ParticipantToFrame = {
         timestamp: 0,
-        name: MOCK_LOCAL_PARTICIPANT.name,
+        name: MOCK_LOCAL_PARTICIPANT.name as string,
         isHost: true,
         avatar: MOCK_AVATAR,
         type: ParticipantType.HOST,
-        color: 'turquoise',
         participantId: MOCK_LOCAL_PARTICIPANT.id,
+        color: MEETING_COLORS.turquoise,
+        id: MOCK_LOCAL_PARTICIPANT.id,
         slot: {
           colorName: 'turquoise',
           index: 0,

--- a/src/components/video/index.ts
+++ b/src/components/video/index.ts
@@ -32,7 +32,7 @@ import {
 import { BaseComponent } from '../base';
 import { ComponentNames } from '../types';
 
-import { ParticipandToFrame, VideoComponentOptions } from './types';
+import { ParticipantToFrame, VideoComponentOptions } from './types';
 import { MEETING_COLORS } from '../../common/types/meeting-colors.types';
 
 const KICK_PARTICIPANTS_TIME = 1000 * 60;
@@ -321,14 +321,17 @@ export class VideoConference extends BaseComponent {
    * */
   private createParticipantFromPresence = (
     participant: PresenceEvent<Participant>,
-  ): Participant => {
+  ): ParticipantToFrame => {
     return {
+      participantId: participant.id,
       id: participant.id,
       color: participant.data.slot?.color || MEETING_COLORS.gray,
       avatar: participant.data.avatar,
       type: participant.data.type,
       name: participant.data.name,
       isHost: participant.data.isHost,
+      timestamp: participant.timestamp,
+      slot: participant.data.slot,
     };
   };
 
@@ -672,11 +675,12 @@ export class VideoConference extends BaseComponent {
    */
   private onRealtimeParticipantsDidChange = (participants: Participant[]): void => {
     this.logger.log('video conference @ on participants did change', participants);
-    const participantList: ParticipandToFrame[] = participants.map((participant) => {
+    const participantList: ParticipantToFrame[] = participants.map((participant) => {
       return {
+        id: participant.id,
         timestamp: participant.timestamp,
         participantId: participant.id,
-        color: participant.slot?.colorName ?? 'gray',
+        color: participant.slot?.color || MEETING_COLORS.gray,
         name: participant.name,
         isHost: participant.isHost ?? false,
         avatar: participant.avatar,

--- a/src/components/video/types.ts
+++ b/src/components/video/types.ts
@@ -1,4 +1,4 @@
-import { Avatar, ParticipantType } from '../../common/types/participant.types';
+import { Avatar, ParticipantType, Slot } from '../../common/types/participant.types';
 import { DevicesOptions } from '../../common/types/sdk-options.types';
 import {
   CamerasPosition,
@@ -46,7 +46,8 @@ export interface VideoComponentOptions {
   };
 }
 
-export type ParticipandToFrame = {
+export type ParticipantToFrame = {
+  id: string;
   timestamp: number;
   participantId: string;
   color: string;
@@ -54,4 +55,5 @@ export type ParticipandToFrame = {
   isHost: boolean;
   avatar?: Avatar;
   type: ParticipantType;
+  slot: Slot;
 };

--- a/src/core/launcher/index.test.ts
+++ b/src/core/launcher/index.test.ts
@@ -249,7 +249,7 @@ describe('Launcher', () => {
       LauncherInstance['onAuthentication'](false);
       expect(LauncherInstance.destroy).toHaveBeenCalled();
       expect(console.error).toHaveBeenCalledWith(
-        `Room can't be initialized because this website's domain is not whitelisted. If you are the developer, please add your domain in https://dashboard.superviz.com/developer`,
+        `[SuperViz] Room cannot be initialized because this website's domain is not whitelisted. If you are the developer, please add your domain in https://dashboard.superviz.com/developer`,
       );
     });
 

--- a/src/core/launcher/index.ts
+++ b/src/core/launcher/index.ts
@@ -396,6 +396,7 @@ export class Launcher extends Observable implements DefaultLauncher {
 
     this.logger.log('launcher service @ onParticipantLeave - participant left', presence.data);
     this.publish(ParticipantEvent.LEFT, presence.data);
+    this.publish(ParticipantEvent.LIST_UPDATED, Object.values(participantsMap));
   };
 
   /**
@@ -422,17 +423,21 @@ export class Launcher extends Observable implements DefaultLauncher {
     }
 
     const { participants } = useStore(StoreType.GLOBAL);
+    const participant: Participant = {
+      id: presence.id,
+      name: presence.name,
+      timestamp: presence.timestamp,
+      ...presence.data,
+    };
 
     if (!participants.value[presence.id]) {
-      this.publish(ParticipantEvent.JOINED, presence.data);
+      this.publish(ParticipantEvent.JOINED, participant);
     }
 
-    const participantsMap = { ...participants.value };
-    participantsMap[presence.id] = {
-      ...presence.data,
-      ...participants.value[presence.id],
-      timestamp: presence.timestamp,
-    };
+    const participantsMap = Object.assign({}, participants.value);
+    participantsMap[presence.id] = participant;
+
+    if (isEqual(participantsMap, participants.value)) return;
 
     participants.publish(participantsMap);
 

--- a/src/core/launcher/index.ts
+++ b/src/core/launcher/index.ts
@@ -48,7 +48,7 @@ export class Launcher extends Observable implements DefaultLauncher {
     localParticipant.publish({ ...participant });
     participants.subscribe(this.onParticipantListUpdate);
     isDomainWhitelisted.subscribe(this.onAuthentication);
-    localParticipant.subscribe(this.onParticipantLocalParticipantUpdateOnStore);
+    localParticipant.subscribe(this.onLocalParticipantUpdateOnStore);
 
     group.publish(participantGroup);
     this.ioc = new IOC(localParticipant.value);
@@ -243,12 +243,12 @@ export class Launcher extends Observable implements DefaultLauncher {
   };
 
   /**
-   * @function onParticipantLocalParticipantUpdateOnStore
-   * @description on participant local participant update on store
+   * @function onLocalParticipantUpdateOnStore
+   * @description handles the update of the local participant in the store.
    * @param {Participant} participant - new participant data
    * @returns {void}
    */
-  private onParticipantLocalParticipantUpdateOnStore = (participant: Participant): void => {
+  private onLocalParticipantUpdateOnStore = (participant: Participant): void => {
     this.participant = participant;
   };
 

--- a/src/core/launcher/index.ts
+++ b/src/core/launcher/index.ts
@@ -228,12 +228,18 @@ export class Launcher extends Observable implements DefaultLauncher {
     return true;
   };
 
+  /**
+   * @function onAuthentication
+   * @description on authentication
+   * @param isAuthenticated - return if the user is authenticated
+   * @returns {void}
+   */
   private onAuthentication = (isAuthenticated: boolean): void => {
     if (isAuthenticated) return;
 
     this.destroy();
     console.error(
-      `Room can't be initialized because this website's domain is not whitelisted. If you are the developer, please add your domain in https://dashboard.superviz.com/developer`,
+      `[SuperViz] Room cannot be initialized because this website's domain is not whitelisted. If you are the developer, please add your domain in https://dashboard.superviz.com/developer`,
     );
   };
 

--- a/src/services/slot/index.test.ts
+++ b/src/services/slot/index.test.ts
@@ -1,4 +1,10 @@
 import { SlotService } from '.';
+import { MOCK_LOCAL_PARTICIPANT } from '../../../__mocks__/participants.mock';
+import { MEETING_COLORS, MEETING_COLORS_KEYS } from '../../common/types/meeting-colors.types';
+import { Participant } from '../../common/types/participant.types';
+import { StoreType } from '../../common/types/stores.types';
+import { useStore } from '../../common/utils/use-store';
+import { ComponentNames } from '../../components/types';
 
 describe('slot service', () => {
   afterEach(() => {
@@ -16,11 +22,7 @@ describe('slot service', () => {
       },
     } as any;
 
-    const participant = {
-      id: '123',
-    } as any;
-
-    const instance = new SlotService(room);
+    const instance = new SlotService(room, useStore);
     const result = await instance.assignSlot();
 
     expect(instance['slotIndex']).toBeDefined();
@@ -30,6 +32,30 @@ describe('slot service', () => {
       textColor: expect.any(String),
       colorName: expect.any(String),
       timestamp: expect.any(Number),
+    });
+  });
+
+  test('should remove the slot from the participant', async () => {
+    const room = {
+      presence: {
+        on: jest.fn(),
+        update: jest.fn(),
+      },
+    } as any;
+
+    const instance = new SlotService(room, useStore);
+    instance['slotIndex'] = 0;
+    instance.setDefaultSlot();
+
+    expect(instance['slotIndex']).toBeNull();
+    expect(room.presence.update).toHaveBeenCalledWith({
+      slot: {
+        index: null,
+        color: expect.any(String),
+        textColor: expect.any(String),
+        colorName: expect.any(String),
+        timestamp: expect.any(Number),
+      },
     });
   });
 
@@ -46,10 +72,10 @@ describe('slot service', () => {
       },
     } as any;
 
-    const instance = new SlotService(room);
+    const instance = new SlotService(room, useStore);
     await instance.assignSlot();
 
-    expect(instance['slotIndex']).toBeUndefined();
+    expect(instance['slotIndex']).toBeNull();
   });
 
   test('if the slot is already in use, it should assign a new slot', async () => {
@@ -79,7 +105,7 @@ describe('slot service', () => {
       id: '123',
     } as any;
 
-    const instance = new SlotService(room);
+    const instance = new SlotService(room, useStore);
     const result = await instance.assignSlot();
 
     expect(instance['slotIndex']).toBeDefined();
@@ -89,6 +115,43 @@ describe('slot service', () => {
       textColor: expect.any(String),
       colorName: expect.any(String),
       timestamp: expect.any(Number),
+    });
+  });
+
+  test("should remove the slot from the participant when the participant don't need it anymore", async () => {
+    const room = {
+      presence: {
+        on: jest.fn(),
+        update: jest.fn(),
+      },
+    } as any;
+
+    const instance = new SlotService(room, useStore);
+    instance['slotIndex'] = 0;
+
+    const event: Participant = {
+      ...MOCK_LOCAL_PARTICIPANT,
+      slot: {
+        index: 0,
+        color: MEETING_COLORS.turquoise,
+        colorName: MEETING_COLORS_KEYS[0],
+        textColor: '#000',
+        timestamp: 0,
+      },
+      activeComponents: [],
+    };
+
+    const { localParticipant } = useStore(StoreType.GLOBAL);
+    localParticipant.publish(event);
+
+    expect(room.presence.update).toHaveBeenCalledWith({
+      slot: {
+        index: null,
+        color: expect.any(String),
+        textColor: expect.any(String),
+        colorName: expect.any(String),
+        timestamp: expect.any(Number),
+      },
     });
   });
 });

--- a/src/services/slot/index.ts
+++ b/src/services/slot/index.ts
@@ -22,7 +22,7 @@ export class SlotService {
     this.room.presence.on(Socket.PresenceEvents.UPDATE, this.onPresenceUpdate);
 
     const { localParticipant } = this.useStore(StoreType.GLOBAL);
-    localParticipant.subscribe(this.onParticipantLocalParticipantUpdateOnStore);
+    localParticipant.subscribe(this.onLocalParticipantUpdateOnStore);
 
     /**
      * When the participant enters the room, is setted the default slot
@@ -165,12 +165,12 @@ export class SlotService {
   };
 
   /**
-   * @function onParticipantLocalParticipantUpdateOnStore
-   * @description on participant local participant update on store
+   * @function onLocalParticipantUpdateOnStore
+   * @description handles the update of the local participant in the store.
    * @param {Participant} participant - new participant data
    * @returns {void}
    */
-  private onParticipantLocalParticipantUpdateOnStore = (participant: Participant): void => {
+  private onLocalParticipantUpdateOnStore = (participant: Participant): void => {
     const COMPONENTS_THAT_NEED_SLOT = [
       ComponentNames.FORM_ELEMENTS,
       ComponentNames.WHO_IS_ONLINE,

--- a/src/services/slot/index.ts
+++ b/src/services/slot/index.ts
@@ -1,19 +1,33 @@
 import * as Socket from '@superviz/socket-client';
 
-import { NAME_IS_WHITE_TEXT, MEETING_COLORS } from '../../common/types/meeting-colors.types';
-import { Participant, Slot } from '../../common/types/participant.types';
-import { StoreType } from '../../common/types/stores.types';
+import {
+  NAME_IS_WHITE_TEXT,
+  MEETING_COLORS,
+  MEETING_COLORS_KEYS,
+} from '../../common/types/meeting-colors.types';
+import { Participant, ParticipantType, Slot } from '../../common/types/participant.types';
+import { Store, StoreType } from '../../common/types/stores.types';
 import { useStore } from '../../common/utils/use-store';
+import { ComponentNames } from '../../components/types';
 
 export class SlotService {
-  private room: Socket.Room;
+  private slotIndex: number | null = null;
 
-  private slotIndex: number;
-
-  constructor(room: Socket.Room) {
+  constructor(
+    private room: Socket.Room,
+    private useStore: <T extends StoreType>(name: T) => Store<T>,
+  ) {
     this.room = room;
 
     this.room.presence.on(Socket.PresenceEvents.UPDATE, this.onPresenceUpdate);
+
+    const { localParticipant } = this.useStore(StoreType.GLOBAL);
+    localParticipant.subscribe(this.onParticipantLocalParticipantUpdateOnStore);
+
+    /**
+     * When the participant enters the room, is setted the default slot
+     */
+    this.setDefaultSlot();
   }
 
   /**
@@ -48,6 +62,7 @@ export class SlotService {
       });
 
       const isUsing = !slots.includes(slot);
+
       if (isUsing) {
         slot = slots.shift();
       }
@@ -86,10 +101,44 @@ export class SlotService {
     }
   }
 
-  private onPresenceUpdate = async (event: Socket.PresenceEvent<Participant>) => {
+  /**
+   * @function setDefaultSlot
+   * @description Removes the slot from the participant
+   * @returns void
+   */
+  public setDefaultSlot() {
     const { localParticipant, participants } = useStore(StoreType.GLOBAL);
 
-    if (!event.data.slot || !localParticipant.value?.slot) return;
+    const slot: Slot = {
+      index: null,
+      color: MEETING_COLORS.gray,
+      textColor: '#fff',
+      colorName: 'gray',
+      timestamp: Date.now(),
+    };
+
+    this.slotIndex = slot.index;
+
+    localParticipant.publish({
+      ...localParticipant.value,
+      slot: slot,
+    });
+
+    participants.publish({
+      ...participants.value,
+      [localParticipant.value.id]: {
+        ...participants.value[localParticipant.value.id],
+        slot,
+      },
+    });
+
+    this.room.presence.update({ slot });
+  }
+
+  private onPresenceUpdate = async (event: Socket.PresenceEvent<Participant>) => {
+    const { localParticipant } = this.useStore(StoreType.GLOBAL);
+
+    if (!event.data.slot || !localParticipant.value?.slot?.index) return;
 
     if (event.id === localParticipant.value.id) {
       localParticipant.publish({
@@ -112,6 +161,41 @@ export class SlotService {
       console.debug(
         `[SuperViz] - Slot reassigned to ${localParticipant.value.id}, slot: ${slotData.colorName}`,
       );
+    }
+  };
+
+  /**
+   * @function onParticipantLocalParticipantUpdateOnStore
+   * @description on participant local participant update on store
+   * @param {Participant} participant - new participant data
+   * @returns {void}
+   */
+  private onParticipantLocalParticipantUpdateOnStore = (participant: Participant): void => {
+    const COMPONENTS_THAT_NEED_SLOT = [
+      ComponentNames.FORM_ELEMENTS,
+      ComponentNames.WHO_IS_ONLINE,
+      ComponentNames.PRESENCE,
+      ComponentNames.PRESENCE_AUTODESK,
+      ComponentNames.PRESENCE_MATTERPORT,
+      ComponentNames.PRESENCE_THREEJS,
+    ];
+
+    const componentsNeedSlot = COMPONENTS_THAT_NEED_SLOT.some((component) => {
+      return participant.activeComponents.includes(component);
+    });
+
+    const videoNeedSlot =
+      participant.activeComponents.includes(ComponentNames.VIDEO_CONFERENCE) &&
+      participant.type !== ParticipantType.AUDIENCE;
+
+    const needSlot = componentsNeedSlot || videoNeedSlot;
+
+    if ((participant.slot?.index === null || !participant.slot) && needSlot) {
+      this.assignSlot();
+    }
+
+    if (participant.slot?.index !== null && !needSlot) {
+      this.setDefaultSlot();
     }
   };
 }

--- a/src/web-components/who-is-online/components/messages.ts
+++ b/src/web-components/who-is-online/components/messages.ts
@@ -10,6 +10,7 @@ import importStyle from '../../base/utils/importStyle';
 import { messagesStyle } from '../css';
 
 import { HorizontalSide, VerticalSide } from './types';
+import { MEETING_COLORS } from '../../../common/types/meeting-colors.types';
 
 const WebComponentsBaseElement = WebComponentsBase(LitElement);
 const styles: CSSResultGroup[] = [WebComponentsBaseElement.styles, messagesStyle];
@@ -38,7 +39,7 @@ export class WhoIsOnlineMessages extends WebComponentsBaseElement {
     super();
     const { localParticipant } = this.useStore(StoreType.GLOBAL);
     localParticipant.subscribe((participant: Participant) => {
-      this.participantColor = participant.slot.color;
+      this.participantColor = participant.slot?.color ?? MEETING_COLORS.gray;
     });
 
     const { following } = this.useStore(StoreType.WHO_IS_ONLINE);

--- a/src/web-components/who-is-online/components/messages.ts
+++ b/src/web-components/who-is-online/components/messages.ts
@@ -38,7 +38,7 @@ export class WhoIsOnlineMessages extends WebComponentsBaseElement {
     super();
     const { localParticipant } = this.useStore(StoreType.GLOBAL);
     localParticipant.subscribe((participant: Participant) => {
-      this.participantColor = participant.color;
+      this.participantColor = participant.slot.color;
     });
 
     const { following } = this.useStore(StoreType.WHO_IS_ONLINE);


### PR DESCRIPTION
Previously, when a user entered the room, we would assign them a slot, now we only assign slots to users who need a slot. 

Example: If a user is in real-time, they don't need a slot because it's not a slot for anything. But if a user is in WIO, they will need a slot because it's used to show what colour that user has. 

To improve this logic, we observe the user list in the store, find what's component is active in this time, when has a component that need slot, we assign a slot to user. If it doesn't, we assign the default slot to the user, in this case the grey slot. 

--- 

There is also an edge case, users that are only in video and the type is `audience` shouldn't have a slot too.