### PR TITLE
Implement connection limits by product instead of by room

### DIFF
--- a/__mocks__/limits.mock.ts
+++ b/__mocks__/limits.mock.ts
@@ -1,8 +1,17 @@
 import { ComponentLimits } from '../src/services/limits/types';
 
 export const LIMITS_MOCK: ComponentLimits = {
-  videoConference: true,
-  presence: true,
-  comments: true,
-  transcript: true,
+  presence: {
+    canUse: true,
+    maxParticipants: 50,
+  },
+  realtime: {
+    canUse: true,
+    maxParticipants: 200,
+  },
+  videoConference: {
+    canUse: true,
+    maxParticipants: 255,
+    canUseTranscript: true,
+  },
 };

--- a/src/components/base/index.test.ts
+++ b/src/components/base/index.test.ts
@@ -13,6 +13,7 @@ import { useGlobalStore } from '../../services/stores';
 import { ComponentNames } from '../types';
 
 import { BaseComponent } from '.';
+import { LIMITS_MOCK } from '../../../__mocks__/limits.mock';
 
 class DummyComponent extends BaseComponent {
   protected logger: Logger;
@@ -70,6 +71,7 @@ describe('BaseComponent', () => {
         config: MOCK_CONFIG,
         eventBus: EVENT_BUS_MOCK,
         Presence3DManagerService: Presence3DManager,
+        connectionLimit: LIMITS_MOCK.videoConference.maxParticipants,
         useStore,
       });
 
@@ -90,6 +92,7 @@ describe('BaseComponent', () => {
         ioc: new IOC(MOCK_LOCAL_PARTICIPANT),
         config: MOCK_CONFIG,
         eventBus: EVENT_BUS_MOCK,
+        connectionLimit: LIMITS_MOCK.videoConference.maxParticipants,
         useStore,
       });
 
@@ -109,6 +112,7 @@ describe('BaseComponent', () => {
         ioc: new IOC(MOCK_LOCAL_PARTICIPANT),
         config: MOCK_CONFIG,
         eventBus: EVENT_BUS_MOCK,
+        connectionLimit: LIMITS_MOCK.videoConference.maxParticipants,
         useStore,
       });
 
@@ -126,8 +130,9 @@ describe('BaseComponent', () => {
           config: null as unknown as Configuration,
           eventBus: null as unknown as EventBus,
           useStore: null as unknown as typeof useStore,
+          connectionLimit: LIMITS_MOCK.videoConference.maxParticipants,
         });
-      }).toThrowError();
+      }).toThrow();
     });
   });
 
@@ -141,6 +146,7 @@ describe('BaseComponent', () => {
         ioc: new IOC(MOCK_LOCAL_PARTICIPANT),
         config: MOCK_CONFIG,
         eventBus: EVENT_BUS_MOCK,
+        connectionLimit: LIMITS_MOCK.videoConference.maxParticipants,
         useStore,
       });
 
@@ -162,6 +168,7 @@ describe('BaseComponent', () => {
         ioc: new IOC(MOCK_LOCAL_PARTICIPANT),
         config: MOCK_CONFIG,
         eventBus: EVENT_BUS_MOCK,
+        connectionLimit: LIMITS_MOCK.videoConference.maxParticipants,
         useStore,
       });
 

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -15,6 +15,7 @@ import { DefaultAttachComponentOptions } from './types';
 export abstract class BaseComponent extends Observable {
   public abstract name: ComponentNames;
   protected abstract logger: Logger;
+  protected connectionLimit: number | 'unlimited';
   protected group: Group;
   protected ioc: IOC;
   protected eventBus: EventBus;
@@ -51,7 +52,8 @@ export abstract class BaseComponent extends Observable {
     this.eventBus = eventBus;
     this.isAttached = true;
     this.ioc = ioc;
-    this.room = ioc.createRoom(this.name);
+    this.connectionLimit = params.connectionLimit ?? 50;
+    this.room = ioc.createRoom(this.name, this.connectionLimit);
 
     if (!hasJoinedRoom.value) {
       this.logger.log(`${this.name} @ attach - not joined yet`);

--- a/src/components/base/types.ts
+++ b/src/components/base/types.ts
@@ -11,6 +11,7 @@ export interface DefaultAttachComponentOptions {
   eventBus: EventBus;
   useStore: <T extends StoreType>(name: T) => Store<T>;
   Presence3DManagerService: typeof Presence3DManager;
+  connectionLimit: number | 'unlimited';
 }
 
 export type GlobalStore = {

--- a/src/components/comments/index.test.ts
+++ b/src/components/comments/index.test.ts
@@ -17,6 +17,7 @@ import { ComponentNames } from '../types';
 import { PinAdapter, CommentsSide, Annotation, PinCoordinates } from './types';
 
 import { Comments } from './index';
+import { LIMITS_MOCK } from '../../../__mocks__/limits.mock';
 
 const MOCK_PARTICIPANTS: ParticipantByGroupApi[] = [
   {
@@ -83,6 +84,7 @@ describe('Comments', () => {
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
       Presence3DManagerService: Presence3DManager,
+      connectionLimit: LIMITS_MOCK.presence.maxParticipants,
       useStore,
     });
 
@@ -337,6 +339,7 @@ describe('Comments', () => {
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
       Presence3DManagerService: Presence3DManager,
+      connectionLimit: LIMITS_MOCK.presence.maxParticipants,
       useStore,
     });
 
@@ -356,6 +359,7 @@ describe('Comments', () => {
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
       Presence3DManagerService: Presence3DManager,
+      connectionLimit: LIMITS_MOCK.presence.maxParticipants,
       useStore,
     });
 

--- a/src/components/form-elements/index.test.ts
+++ b/src/components/form-elements/index.test.ts
@@ -10,6 +10,7 @@ import { ComponentNames } from '../types';
 import { FieldEvents } from './types';
 
 import { FormElements } from '.';
+import { LIMITS_MOCK } from '../../../__mocks__/limits.mock';
 
 describe('form elements', () => {
   let instance: any;
@@ -32,6 +33,7 @@ describe('form elements', () => {
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
       Presence3DManagerService: Presence3DManager,
+      connectionLimit: LIMITS_MOCK.presence.maxParticipants,
       useStore,
     });
   });

--- a/src/components/presence-mouse/canvas/index.test.ts
+++ b/src/components/presence-mouse/canvas/index.test.ts
@@ -1,6 +1,7 @@
 import { MOCK_CANVAS } from '../../../../__mocks__/canvas.mock';
 import { MOCK_CONFIG } from '../../../../__mocks__/config.mock';
 import { EVENT_BUS_MOCK } from '../../../../__mocks__/event-bus.mock';
+import { LIMITS_MOCK } from '../../../../__mocks__/limits.mock';
 import { MOCK_LOCAL_PARTICIPANT } from '../../../../__mocks__/participants.mock';
 import { useStore } from '../../../common/utils/use-store';
 import { IOC } from '../../../services/io';
@@ -53,6 +54,7 @@ const createMousePointers = (): PointersCanvas => {
     config: MOCK_CONFIG,
     eventBus: EVENT_BUS_MOCK,
     Presence3DManagerService: Presence3DManager,
+    connectionLimit: LIMITS_MOCK.presence.maxParticipants,
     useStore,
   });
 

--- a/src/components/presence-mouse/html/index.test.ts
+++ b/src/components/presence-mouse/html/index.test.ts
@@ -7,6 +7,7 @@ import { Presence3DManager } from '../../../services/presence-3d-manager';
 import { ParticipantMouse } from '../types';
 
 import { PointersHTML } from '.';
+import { LIMITS_MOCK } from '../../../../__mocks__/limits.mock';
 
 const createMousePointers = (id: string = 'html'): PointersHTML => {
   const presenceMouseComponent = new PointersHTML(id);
@@ -17,6 +18,7 @@ const createMousePointers = (id: string = 'html'): PointersHTML => {
     config: MOCK_CONFIG,
     Presence3DManagerService: Presence3DManager,
     eventBus: EVENT_BUS_MOCK,
+    connectionLimit: LIMITS_MOCK.presence.maxParticipants,
     useStore,
   });
 
@@ -379,6 +381,7 @@ describe('MousePointers on HTML', () => {
         eventBus: EVENT_BUS_MOCK,
         ioc: new IOC(MOCK_LOCAL_PARTICIPANT),
         Presence3DManagerService: Presence3DManager,
+        connectionLimit: LIMITS_MOCK.presence.maxParticipants,
         useStore,
       });
 

--- a/src/components/realtime/channel.test.ts
+++ b/src/components/realtime/channel.test.ts
@@ -1,3 +1,4 @@
+import { LIMITS_MOCK } from '../../../__mocks__/limits.mock';
 import { MOCK_OBSERVER_HELPER } from '../../../__mocks__/observer-helper.mock';
 import { MOCK_LOCAL_PARTICIPANT } from '../../../__mocks__/participants.mock';
 import { IOC } from '../../services/io';
@@ -21,7 +22,8 @@ describe('Realtime Channel', () => {
     ChannelInstance = new Channel(
       'channel',
       new IOC(MOCK_LOCAL_PARTICIPANT),
-      MOCK_LOCAL_PARTICIPANT
+      MOCK_LOCAL_PARTICIPANT,
+      LIMITS_MOCK.realtime.maxParticipants,
     );
 
     ChannelInstance['state'] = RealtimeChannelState.CONNECTED;
@@ -120,7 +122,7 @@ describe('Realtime Channel', () => {
         });
 
       const h = await ChannelInstance.fetchHistory();
-      
+
       expect(spy).toHaveBeenCalled();
       expect(h).toEqual({
         'unit-test-event-name': [
@@ -202,10 +204,10 @@ describe('Realtime Channel', () => {
       ChannelInstance['state'] = RealtimeChannelState.DISCONNECTED;
 
       ChannelInstance.disconnect();
-      
+
       expect(spy).not.toHaveBeenCalled();
     });
-    
+
     test('Should log an error if a disconnect attempt is made when the channel is already disconnected', () => {
       const spy = jest.spyOn(ChannelInstance['logger'], 'log' as any);
       ChannelInstance['state'] = RealtimeChannelState.DISCONNECTED;
@@ -213,6 +215,6 @@ describe('Realtime Channel', () => {
       ChannelInstance.disconnect();
 
       expect(spy).toHaveBeenCalled();
-    })
+    });
   });
-})
+});

--- a/src/components/realtime/channel.ts
+++ b/src/components/realtime/channel.ts
@@ -20,13 +20,18 @@ export class Channel extends Observable {
     callback: (data: unknown) => void;
   }> = [];
 
-  constructor(name: string, ioc: IOC, localParticipant: Participant) {
+  constructor(
+    name: string,
+    ioc: IOC,
+    localParticipant: Participant,
+    connectionLimit: number | 'unlimited',
+  ) {
     super();
 
     this.name = name;
     this.ioc = ioc;
     this.logger = new Logger('@superviz/sdk/realtime-channel');
-    this.channel = this.ioc.createRoom(`realtime:${this.name}`);
+    this.channel = this.ioc.createRoom(`realtime:${this.name}`, connectionLimit);
     this.localParticipant = localParticipant;
 
     this.subscribeToRealtimeEvents();

--- a/src/components/realtime/index.test.ts
+++ b/src/components/realtime/index.test.ts
@@ -8,6 +8,7 @@ import { Presence3DManager } from '../../services/presence-3d-manager';
 import { RealtimeComponentState } from './types';
 
 import { Realtime } from '.';
+import { LIMITS_MOCK } from '../../../__mocks__/limits.mock';
 
 jest.mock('lodash/throttle', () => jest.fn((fn) => fn));
 jest.useFakeTimers();
@@ -27,6 +28,7 @@ describe('realtime component', () => {
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
       Presence3DManagerService: Presence3DManager,
+      connectionLimit: LIMITS_MOCK.realtime.maxParticipants,
       useStore,
     });
 

--- a/src/components/realtime/index.ts
+++ b/src/components/realtime/index.ts
@@ -55,7 +55,7 @@ export class Realtime extends BaseComponent {
 
     if (channel) return channel;
 
-    channel = new Channel(name, this.ioc, this.localParticipant);
+    channel = new Channel(name, this.ioc, this.localParticipant, this.connectionLimit);
 
     this.channels.set(name, channel);
 
@@ -100,7 +100,7 @@ export class Realtime extends BaseComponent {
 
   protected start(): void {
     this.logger.log('started');
-    this.channel = new Channel('default', this.ioc, this.localParticipant);
+    this.channel = new Channel('default', this.ioc, this.localParticipant, this.connectionLimit);
 
     this.channel.subscribe(RealtimeChannelEvent.REALTIME_CHANNEL_STATE_CHANGED, (state) => {
       if (state !== RealtimeChannelState.CONNECTED) return;

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -14,10 +14,10 @@ export enum ComponentNames {
 }
 
 export enum PresenceMap {
+  'comments' = 'presence',
   'presence3dMatterport' = 'presence',
   'presence3dAutodesk' = 'presence',
   'presence3dThreejs' = 'presence',
-  'realtime' = 'presence',
   'whoIsOnline' = 'presence',
   'formElements' = 'presence',
 }

--- a/src/components/video/index.test.ts
+++ b/src/components/video/index.test.ts
@@ -26,6 +26,7 @@ import { ParticipantToFrame } from './types';
 
 import { VideoConference } from '.';
 import { MEETING_COLORS } from '../../common/types/meeting-colors.types';
+import { LIMITS_MOCK } from '../../../__mocks__/limits.mock';
 
 Object.assign(global, { TextDecoder, TextEncoder });
 
@@ -94,6 +95,7 @@ describe('VideoConference', () => {
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
       Presence3DManagerService: Presence3DManager,
+      connectionLimit: LIMITS_MOCK.videoConference.maxParticipants,
       useStore,
     });
 
@@ -118,6 +120,7 @@ describe('VideoConference', () => {
       Presence3DManagerService: Presence3DManager,
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
+      connectionLimit: LIMITS_MOCK.videoConference.maxParticipants,
       useStore,
     });
 

--- a/src/components/who-is-online/index.test.ts
+++ b/src/components/who-is-online/index.test.ts
@@ -17,6 +17,7 @@ import { Avatar, WhoIsOnlineParticipant, TooltipData } from './types';
 
 import { WhoIsOnline } from './index';
 import { MEETING_COLORS } from '../../common/types/meeting-colors.types';
+import { LIMITS_MOCK } from '../../../__mocks__/limits.mock';
 
 const generateMockParticipant = ({
   id,
@@ -61,6 +62,7 @@ describe('Who Is Online', () => {
       config: MOCK_CONFIG,
       eventBus: EVENT_BUS_MOCK,
       Presence3DManagerService: Presence3DManager,
+      connectionLimit: LIMITS_MOCK.presence.maxParticipants,
       useStore,
     });
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -107,9 +107,8 @@ const init = async (apiKey: string, options: SuperVizSdkOptions): Promise<Launch
     throw new Error('Failed to validate API key');
   }
 
-  const [environment, limits, waterMark] = await Promise.all([
+  const [environment, waterMark] = await Promise.all([
     ApiService.fetchConfig(apiUrl, apiKey),
-    ApiService.fetchLimits(apiUrl, apiKey),
     ApiService.fetchWaterMark(apiUrl, apiKey),
   ]).catch(() => {
     throw new Error('Failed to load configuration from server');
@@ -130,7 +129,21 @@ const init = async (apiKey: string, options: SuperVizSdkOptions): Promise<Launch
     environment: (options.environment as EnvironmentTypes) ?? EnvironmentTypes.PROD,
     roomId,
     debug: options.debug,
-    limits,
+    limits: {
+      presence: {
+        canUse: true,
+        maxParticipants: 50,
+      },
+      realtime: {
+        canUse: true,
+        maxParticipants: 200,
+      },
+      videoConference: {
+        canUse: true,
+        maxParticipants: 255,
+        canUseTranscript: true,
+      },
+    },
     waterMark,
     colors: options.customColors,
     features,
@@ -141,7 +154,7 @@ const init = async (apiKey: string, options: SuperVizSdkOptions): Promise<Launch
   ApiService.createOrUpdateParticipant({
     name: participant.name,
     participantId: participant.id,
-    avatar: participant.avatar?.imageUrl, 
+    avatar: participant.avatar?.imageUrl,
   });
 
   return LauncherFacade(options);

--- a/src/core/launcher/index.test.ts
+++ b/src/core/launcher/index.test.ts
@@ -16,6 +16,7 @@ import { useGlobalStore } from '../../services/stores';
 import { LauncherFacade, LauncherOptions } from './types';
 
 import Facade, { Launcher } from '.';
+import { LIMITS_MOCK } from '../../../__mocks__/limits.mock';
 
 jest.mock('../../services/limits');
 
@@ -59,7 +60,7 @@ describe('Launcher', () => {
 
   describe('Components', () => {
     test('should not add component if realtime is not joined room', () => {
-      LimitsService.checkComponentLimit = jest.fn().mockReturnValue(true);
+      LimitsService.checkComponentLimit = jest.fn().mockReturnValue(LIMITS_MOCK.videoConference);
       const { hasJoinedRoom } = useStore(StoreType.GLOBAL);
       hasJoinedRoom.publish(false);
 
@@ -73,7 +74,7 @@ describe('Launcher', () => {
     });
 
     test('should add component', () => {
-      LimitsService.checkComponentLimit = jest.fn().mockReturnValue(true);
+      LimitsService.checkComponentLimit = jest.fn().mockReturnValue(LIMITS_MOCK.videoConference);
 
       LauncherInstance.addComponent(MOCK_COMPONENT);
 
@@ -82,6 +83,7 @@ describe('Launcher', () => {
           ioc: expect.any(IOC),
           config: MOCK_CONFIG,
           eventBus: EVENT_BUS_MOCK,
+          connectionLimit: LIMITS_MOCK.videoConference.maxParticipants,
           useStore,
         } as DefaultAttachComponentOptions),
       );
@@ -93,7 +95,10 @@ describe('Launcher', () => {
     });
 
     test('should show a console message if limit reached and not add component', () => {
-      LimitsService.checkComponentLimit = jest.fn().mockReturnValue(false);
+      LimitsService.checkComponentLimit = jest.fn().mockReturnValue({
+        ...LIMITS_MOCK.videoConference,
+        canUse: false,
+      });
 
       LauncherInstance.addComponent(MOCK_COMPONENT);
 
@@ -101,7 +106,7 @@ describe('Launcher', () => {
     });
 
     test('should remove component', () => {
-      LimitsService.checkComponentLimit = jest.fn().mockReturnValue(true);
+      LimitsService.checkComponentLimit = jest.fn().mockReturnValue(LIMITS_MOCK.videoConference);
 
       LauncherInstance.addComponent(MOCK_COMPONENT);
       LauncherInstance.removeComponent(MOCK_COMPONENT);
@@ -115,11 +120,11 @@ describe('Launcher', () => {
     test('should show a console message if component is not initialized yet', () => {
       LauncherInstance.removeComponent(MOCK_COMPONENT);
 
-      expect(MOCK_COMPONENT.detach).not.toBeCalled();
+      expect(MOCK_COMPONENT.detach).not.toHaveBeenCalled();
     });
 
     test('should show a console message if component is already active', () => {
-      LimitsService.checkComponentLimit = jest.fn().mockReturnValue(true);
+      LimitsService.checkComponentLimit = jest.fn().mockReturnValue(LIMITS_MOCK.videoConference);
 
       LauncherInstance.addComponent(MOCK_COMPONENT);
       LauncherInstance.addComponent(MOCK_COMPONENT);

--- a/src/core/launcher/index.ts
+++ b/src/core/launcher/index.ts
@@ -98,6 +98,11 @@ export class Launcher extends Observable implements DefaultLauncher {
       activeComponents: this.activeComponents,
     });
 
+    this.room.presence.update({
+      ...localParticipant.value,
+      activeComponents: this.activeComponents,
+    });
+
     ApiService.sendActivity(
       localParticipant.value.id,
       group.value.id,
@@ -348,9 +353,7 @@ export class Launcher extends Observable implements DefaultLauncher {
       Socket.PresenceEvents.JOINED_ROOM,
       this.onParticipantJoinedIOC,
     );
-
     this.room.presence.on<Participant>(Socket.PresenceEvents.LEAVE, this.onParticipantLeaveIOC);
-
     this.room.presence.on<Participant>(Socket.PresenceEvents.UPDATE, this.onParticipantUpdatedIOC);
 
     const { hasJoinedRoom } = useStore(StoreType.GLOBAL);

--- a/src/core/launcher/index.ts
+++ b/src/core/launcher/index.ts
@@ -52,7 +52,7 @@ export class Launcher extends Observable implements DefaultLauncher {
 
     group.publish(participantGroup);
     this.ioc = new IOC(localParticipant.value);
-    this.room = this.ioc.createRoom('launcher');
+    this.room = this.ioc.createRoom('launcher', 'unlimited');
 
     // internal events without realtime
     this.eventBus = new EventBus();
@@ -79,12 +79,15 @@ export class Launcher extends Observable implements DefaultLauncher {
       return;
     }
 
+    const limit = LimitsService.checkComponentLimit(component.name);
+
     component.attach({
       ioc: this.ioc,
       config: config.configuration,
       eventBus: this.eventBus,
       useStore,
       Presence3DManagerService: Presence3DManager,
+      connectionLimit: limit.maxParticipants,
     });
 
     this.activeComponents.push(component.name);
@@ -191,7 +194,7 @@ export class Launcher extends Observable implements DefaultLauncher {
    */
   private canAddComponent = (component: Partial<BaseComponent>): boolean => {
     const isProvidedFeature = config.get<boolean>(`features.${component.name}`);
-    const hasComponentLimit = LimitsService.checkComponentLimit(component.name);
+    const componentLimit = LimitsService.checkComponentLimit(component.name);
     const isComponentActive = this.activeComponents.includes(component.name);
 
     const verifications = [
@@ -209,7 +212,7 @@ export class Launcher extends Observable implements DefaultLauncher {
         message: `Component ${component.name} is already active. Please remove it first`,
       },
       {
-        isValid: hasComponentLimit,
+        isValid: componentLimit.canUse,
         message: `You reached the limit usage of ${component.name}`,
       },
     ];

--- a/src/services/io/index.ts
+++ b/src/services/io/index.ts
@@ -99,11 +99,14 @@ export class IOC {
   /**
    * @function createRoom
    * @description create and join realtime room
-   * @param roomName {string}
+   * @param {string} roomName - name of the room that will be created
+   * @param {number | 'unlimited'} connectionLimit -
+   *  connection limit for the room, the default is 50 because it's the maximum number of slots
    * @returns {Room}
    */
-  public createRoom(roomName: string): Socket.Room {
+  public createRoom(roomName: string, connectionLimit: number | 'unlimited' = 50): Socket.Room {
     const roomId = config.get<string>('roomId');
-    return this.client.connect(`${roomId}:${roomName}`);
+
+    return this.client.connect(`${roomId}:${roomName}`, connectionLimit);
   }
 }

--- a/src/services/limits/index.test.ts
+++ b/src/services/limits/index.test.ts
@@ -3,6 +3,7 @@ import { ComponentNames } from '../../components/types';
 import config from '../config';
 
 import LimitsService from './index';
+import { ComponentLimits } from './types';
 
 describe('LimitsService', () => {
   describe('checkComponentLimit', () => {
@@ -12,20 +13,25 @@ describe('LimitsService', () => {
 
       const result = LimitsService.checkComponentLimit(componentName);
 
-      expect(result).toBe(true);
+      expect(result).toBe(LIMITS_MOCK.videoConference);
     });
 
     it('should return false if the component limit is exceeded', () => {
       const componentName = ComponentNames.COMMENTS;
 
-      jest.spyOn(config, 'get').mockReturnValue({
+      const expected: ComponentLimits = {
         ...LIMITS_MOCK,
-        comments: false,
-      });
+        presence: {
+          ...LIMITS_MOCK.presence,
+          canUse: false,
+        },
+      };
+
+      jest.spyOn(config, 'get').mockReturnValue(expected);
 
       const result = LimitsService.checkComponentLimit(componentName);
 
-      expect(result).toBe(false);
+      expect(result).toBe(expected.presence);
     });
   });
 });

--- a/src/services/limits/index.ts
+++ b/src/services/limits/index.ts
@@ -1,12 +1,13 @@
 import { ComponentNames, PresenceMap } from '../../components/types';
 import config from '../config';
 
-import { ComponentLimits } from './types';
+import { ComponentLimits, Limit, VideoConferenceLimit } from './types';
 
 export default class LimitsService {
-  static checkComponentLimit(name: ComponentNames): boolean {
-    const componentName = PresenceMap[name] ?? name;
+  static checkComponentLimit(name: ComponentNames): Limit | VideoConferenceLimit {
     const limits = config.get<ComponentLimits>('limits');
-    return limits?.[componentName] ?? false;
+    const componentName = PresenceMap[name] ?? name;
+
+    return limits?.[componentName] ?? { canUse: false, maxParticipants: 50 };
   }
 }

--- a/src/services/limits/types.ts
+++ b/src/services/limits/types.ts
@@ -1,6 +1,14 @@
+export type Limit = {
+  canUse: boolean;
+  maxParticipants: number;
+};
+
+export type VideoConferenceLimit = Limit & {
+  canUseTranscript: boolean;
+};
+
 export type ComponentLimits = {
-  videoConference: boolean;
-  presence: boolean;
-  comments: boolean;
-  transcript?: boolean;
+  videoConference: VideoConferenceLimit;
+  presence: Limit;
+  realtime: Limit;
 };

--- a/src/services/slot/index.test.ts
+++ b/src/services/slot/index.test.ts
@@ -141,8 +141,7 @@ describe('slot service', () => {
       activeComponents: [],
     };
 
-    const { localParticipant } = useStore(StoreType.GLOBAL);
-    localParticipant.publish(event);
+    instance['onLocalParticipantUpdateOnStore'](event);
 
     expect(room.presence.update).toHaveBeenCalledWith({
       slot: {

--- a/src/services/slot/index.ts
+++ b/src/services/slot/index.ts
@@ -23,11 +23,6 @@ export class SlotService {
 
     const { localParticipant } = this.useStore(StoreType.GLOBAL);
     localParticipant.subscribe(this.onLocalParticipantUpdateOnStore);
-
-    /**
-     * When the participant enters the room, is setted the default slot
-     */
-    this.setDefaultSlot();
   }
 
   /**


### PR DESCRIPTION
Before that, all the components have the same limit because it's implemented by room, it means all the components follow the maximum connections implemented by room, in this case it was 16 because it was the total slot count. 

After that, the component has the limits by itself, it means we have components that can have more connections and component that can have less connections in the same room. 

Example: if the client is using comments with video, they can connect 255 participants (between audience and guest/host) in the video room, but in the comments room they can only connect 50 participants. 

It will allow more possibilities to the components because they will no longer be limited by the room.

To know what limits we have, and the price, visit: https://www.superviz.com/pricing