### PR TITLE
fix: add target to esm build

### DIFF
--- a/.esbuild/config.js
+++ b/.esbuild/config.js
@@ -37,6 +37,7 @@ const esmConfig = {
   sourcemap: true,
   minify: true,
   splitting: true,
+  target: 'es6',
   format: 'esm',
   define: { global: 'window', 'process.env': JSON.stringify(env) },
 };


### PR DESCRIPTION
In the previous version we improved the build by adding separated files to ESM and CJS. 

But specifically with next js older versions, we have a problem with minify. 

To solve this problem, we add a fixed target to our esm config. 