### PR TITLE
fix: internal video destroys don't remove component from activeComponents list

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "@superviz/socket-client": "1.8.0",
+    "@superviz/socket-client": "1.8.2",
     "bowser": "^2.11.0",
     "bowser-jr": "^1.0.6",
     "debug": "^4.3.4",

--- a/src/components/video/index.ts
+++ b/src/components/video/index.ts
@@ -525,6 +525,25 @@ export class VideoConference extends BaseComponent {
   private onParticipantLeft = (_: Participant): void => {
     this.logger.log('video conference @ on participant left', this.localParticipant);
 
+    const { localParticipant, participants } = this.useStore(StoreType.GLOBAL);
+
+    localParticipant.publish({
+      ...localParticipant.value,
+      activeComponents: localParticipant.value.activeComponents?.filter(
+        (ac) => ac !== ComponentNames.VIDEO_CONFERENCE,
+      ),
+    });
+
+    participants.publish({
+      ...participants.value,
+      [this.localParticipant.id]: {
+        ...localParticipant.value,
+        activeComponents: localParticipant.value.activeComponents?.filter(
+          (ac) => ac !== ComponentNames.VIDEO_CONFERENCE,
+        ),
+      },
+    });
+
     this.connectionService.removeListeners();
     this.publish(MeetingEvent.DESTROY);
     this.publish(MeetingEvent.MY_PARTICIPANT_LEFT, this.localParticipant);

--- a/src/core/launcher/index.ts
+++ b/src/core/launcher/index.ts
@@ -188,9 +188,11 @@ export class Launcher extends Observable implements DefaultLauncher {
    * @returns {boolean}
    */
   private canAddComponent = (component: Partial<BaseComponent>): boolean => {
+    const { localParticipant } = useStore(StoreType.GLOBAL);
+
     const isProvidedFeature = config.get<boolean>(`features.${component.name}`);
     const hasComponentLimit = LimitsService.checkComponentLimit(component.name);
-    const isComponentActive = this.activeComponents.includes(component.name);
+    const isComponentActive = localParticipant.value.activeComponents?.includes(component.name);
 
     const verifications = [
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2666,18 +2666,18 @@
   resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
   integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
 
-"@superviz/socket-client@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@superviz/socket-client/-/socket-client-1.8.0.tgz#6e21f177bc3f5ed128784f14a95a3c4f59d40593"
-  integrity sha512-+jTpYYug8rgugaoBvgfa3GU/zCSi00grwZzwCDZkLXTxil7e3psiZyRUYH9HucPRUT8ULgpplDN5MF9G43E/fQ==
+"@superviz/socket-client@1.8.2":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@superviz/socket-client/-/socket-client-1.8.2.tgz#054a19df95e144ae99f459ce75f38795feffbcb9"
+  integrity sha512-pB4Pq9GYL7iXFN5ppri9D5sG2ff5Yg/muBoT6pgW2scj91OL2741/ULuxcvTZiUtCW6H7ndHuplVMyHCczkIAA==
   dependencies:
     "@reactivex/rxjs" "^6.6.7"
-    debug "^4.3.4"
+    debug "^4.3.5"
     lodash "^4.17.21"
     rxjs "^7.8.1"
     semantic-release-version-file "^1.0.2"
-    socket.io-client "^4.7.4"
-    zod "^3.22.4"
+    socket.io-client "^4.7.5"
+    zod "^3.23.8"
 
 "@tootallnate/once@2":
   version "2.0.0"
@@ -4776,7 +4776,7 @@ debug@^3.1.0, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.3.1:
+debug@^4.3.1, debug@^4.3.5:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.5.tgz#e83444eceb9fedd4a1da56d671ae2446a01a6e1e"
   integrity sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==
@@ -9958,10 +9958,10 @@ smart-buffer@^4.2.0:
   resolved "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-socket.io-client@^4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-4.7.4.tgz#5f0e060ff34ac0a4b4c5abaaa88e0d1d928c64c8"
-  integrity sha512-wh+OkeF0rAVCrABWQBaEjLfb7DVPotMbu0cgWgyR0v6eA4EoVnAwcIeIbcdTE3GT/H3kbdLl7OoH2+asoDRIIg==
+socket.io-client@^4.7.5:
+  version "4.7.5"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-4.7.5.tgz#919be76916989758bdc20eec63f7ee0ae45c05b7"
+  integrity sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==
   dependencies:
     "@socket.io/component-emitter" "~3.1.0"
     debug "~4.3.2"
@@ -11301,7 +11301,7 @@ yoctocolors@^2.0.0:
   resolved "https://registry.yarnpkg.com/yoctocolors/-/yoctocolors-2.0.2.tgz#8e871e30d7eabb1976776e07a9fe2fe9a8c46fba"
   integrity sha512-Ct97huExsu7cWeEjmrXlofevF8CvzUglJ4iGUet5B8xn1oumtAZBpHU4GzYuoE6PVqcZ5hghtBrSlhwHuR1Jmw==
 
-zod@^3.22.4:
-  version "3.22.4"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
-  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==
+zod@^3.23.8:
+  version "3.23.8"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
+  integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==


### PR DESCRIPTION
Fixed a small bug where if the video component was destroyed internally, the component wasn't removed from the `activeComponents` list, preventing the client from adding the component again.