### PR TITLE
fix: active components lists

### DIFF
--- a/src/services/io/index.ts
+++ b/src/services/io/index.ts
@@ -23,7 +23,6 @@ export class IOC {
    */
   public destroy(): void {
     this.client.destroy();
-    this.client.connection.off();
   }
 
   /**
@@ -43,7 +42,7 @@ export class IOC {
 
     if (
       needsToReconnectStates.includes(state.state) &&
-      state.reason !== 'Unauthorized connection'
+      !['io client disconnect', 'Unauthorized connection'].includes(state.reason)
     ) {
       this.forceReconnect();
     }


### PR DESCRIPTION
Making sure the `activeComponents` list is updated and not duplicated, and making sure we're saving the right component instances to destroy when the room is destroyed.

I also noticed that the IOC was forcing a reconnect when the room was destroyed, this was also fixed.