### PR TITLE
feat(core): validate if the user id and room id follow the right pattern

### DIFF
--- a/src/core/index.test.ts
+++ b/src/core/index.test.ts
@@ -149,4 +149,44 @@ describe('initialization errors', () => {
       'Color sv-primary-900 is not a valid color variable value. Please check the documentation for more information.',
     );
   });
+
+  test('should throw an error if room id is invalid', async () => {
+    await expect(
+      sdk(UNIT_TEST_API_KEY, {
+        ...SIMPLE_INITIALIZATION_MOCK,
+        roomId: '<invalid-room-id>',
+      }),
+    ).rejects.toThrow(
+      '[SuperViz] Room id is invalid, it should be between 2 and 64 characters and only accept letters, numbers and special characters: -_&@+=,(){}[]/«».:|\'"',
+    );
+
+    await expect(
+      sdk(UNIT_TEST_API_KEY, {
+        ...SIMPLE_INITIALIZATION_MOCK,
+        roomId: '1',
+      }),
+    ).rejects.toThrow(
+      '[SuperViz] Room id is invalid, it should be between 2 and 64 characters and only accept letters, numbers and special characters: -_&@+=,(){}[]/«».:|\'"',
+    );
+  });
+
+  test('should throw an error if participant id is invalid', async () => {
+    await expect(
+      sdk(UNIT_TEST_API_KEY, {
+        ...SIMPLE_INITIALIZATION_MOCK,
+        participant: { ...SIMPLE_INITIALIZATION_MOCK.participant, id: '<invalid-participant-id>' },
+      }),
+    ).rejects.toThrow(
+      '[SuperViz] Participant id is invalid, it should be between 2 and 64 characters and only accept letters, numbers and special characters: -_&@+=,(){}[]/«».:|\'"',
+    );
+
+    await expect(
+      sdk(UNIT_TEST_API_KEY, {
+        ...SIMPLE_INITIALIZATION_MOCK,
+        participant: { ...SIMPLE_INITIALIZATION_MOCK.participant, id: '1' },
+      }),
+    ).rejects.toThrow(
+      '[SuperViz] Participant id is invalid, it should be between 2 and 64 characters and only accept letters, numbers and special characters: -_&@+=,(){}[]/«».:|\'"',
+    );
+  });
 });

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -11,6 +11,27 @@ import LauncherFacade from './launcher';
 import { LauncherFacade as LauncherFacadeType } from './launcher/types';
 
 /**
+ * @function validateId
+ * @description validate if the id follows the constraints
+ * @param {string} id - id to validate
+ * @returns {boolean}
+ */
+function validateId(id: string): boolean {
+  const lengthConstraint = /^.{2,64}$/;
+  const pattern = /^[-_&@+=,(){}\[\]\/«».:|'"#a-zA-Z0-9À-ÿ\s]*$/;
+
+  if (!lengthConstraint.test(id)) {
+    return false;
+  }
+
+  if (!pattern.test(id)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
  * @function validateOptions
  * @description Validate the options passed to the SDK
  * @param {SuperVizSdkOptions} param
@@ -27,15 +48,27 @@ const validateOptions = ({
   }
 
   if (!group || !group.name || !group.id) {
-    throw new Error('Group fields is required');
+    throw new Error('[SuperViz] Group fields is required');
   }
 
   if (!participant || !participant.id || !participant.name) {
-    throw new Error('Participant name and id is required');
+    throw new Error('[SuperViz] Participant name and id is required');
   }
 
   if (!roomId) {
-    throw new Error('Room id is required');
+    throw new Error('[SuperViz] Room id is required');
+  }
+
+  if (!validateId(roomId)) {
+    throw new Error(
+      '[SuperViz] Room id is invalid, it should be between 2 and 64 characters and only accept letters, numbers and special characters: -_&@+=,(){}[]/«».:|\'"',
+    );
+  }
+
+  if (!validateId(participant.id)) {
+    throw new Error(
+      '[SuperViz] Participant id is invalid, it should be between 2 and 64 characters and only accept letters, numbers and special characters: -_&@+=,(){}[]/«».:|\'"',
+    );
   }
 };
 


### PR DESCRIPTION
Adding validations to ensure the users is following the room id and participant id rules. 

New rules: 

- Length Constraints: Minimum length of 2. Maximum length of 64.
- Pattern: `[-_&@+=,(){}\[\]\/«».:|'"#a-zA-Z0-9À-ÿ\s]*`

New message errors: 

Room ID invalid
```
[SuperViz] Room id is invalid, it should be between 2 and 64 characters and only accept letters, numbers and special characters: -_&@+=,(){}[]/«».:|\'"
```

Participant ID invalid: 

```
[SuperViz] Participant id is invalid, it should be between 2 and 64 characters and only accept letters, numbers and special characters: -_&@+=,(){}[]/«».:|\'"
```