### PR TITLE
fix: only update active instances when a component is added or removed

### DIFF
--- a/src/core/launcher/index.test.ts
+++ b/src/core/launcher/index.test.ts
@@ -114,7 +114,7 @@ describe('Launcher', () => {
 
       LauncherInstance.addComponent(MOCK_COMPONENT);
 
-      expect(MOCK_COMPONENT.attach).not.toBeCalled();
+      expect(MOCK_COMPONENT.attach).not.toHaveBeenCalled();
     });
 
     test('should remove component', () => {

--- a/src/core/launcher/index.ts
+++ b/src/core/launcher/index.ts
@@ -151,7 +151,7 @@ export class Launcher extends Observable implements DefaultLauncher {
    */
   public removeComponent = (component: Partial<BaseComponent>): void => {
     if (!this.activeComponents.includes(component.name)) {
-      const message = `Component ${component.name} is not initialized yet.`;
+      const message = `[SuperViz] Component ${component.name} is not initialized yet.`;
       this.logger.log(message);
       console.error(message);
       return;
@@ -216,20 +216,20 @@ export class Launcher extends Observable implements DefaultLauncher {
     const verifications = [
       {
         isValid: isProvidedFeature,
-        message: `Component ${component.name} is not enabled in the room`,
+        message: `[SuperViz] Component ${component.name} is not enabled in the room`,
       },
       {
         isValid: !this.isDestroyed,
         message:
-          'Component can not be added because the superviz room is destroyed. Initialize a new room to add and use components.',
+          '[SuperViz] Component can not be added because the superviz room is destroyed. Initialize a new room to add and use components.',
       },
       {
         isValid: !isComponentActive,
-        message: `Component ${component.name} is already active. Please remove it first`,
+        message: `[SuperViz] Component ${component.name} is already active. Please remove it first`,
       },
       {
         isValid: componentLimit.canUse,
-        message: `You reached the limit usage of ${component.name}`,
+        message: `[SuperViz] You reached the limit usage of ${component.name}`,
       },
     ];
 

--- a/src/services/io/index.ts
+++ b/src/services/io/index.ts
@@ -22,6 +22,7 @@ export class IOC {
    * @returns {void}
    */
   public destroy(): void {
+    this.stateSubject.complete();
     this.client.destroy();
   }
 


### PR DESCRIPTION
Before, we update the active instances every time the local subscriber is updated in the store, but we have a lot of updates in the store, every time the subscriber is updated. 

So, to improve this flow and prevent problems, we're going to update the active instances only when the customer adds and removes a component, to prevent duplication, we're going to validate and replace the instance when it's necessary. 